### PR TITLE
Supporting live dot coloring (by default tint is used)

### DIFF
--- a/PlayerControls/PlayerControls.xcodeproj/project.pbxproj
+++ b/PlayerControls/PlayerControls.xcodeproj/project.pbxproj
@@ -51,7 +51,7 @@
 			outputFiles = (
 				"$(DERIVED_SOURCES_DIR)/$(INPUT_FILE_BASE).generated.swift",
 			);
-			script = "set -e\n\nif ! which sourcery > /dev/null; then\n    echo \"error: Sourcery is missing. Make brew install sourcery.\"\n    exit 1\nfi\n\nsourcery --sources sources --templates $INPUT_FILE_DIR/$INPUT_FILE_NAME --output $DERIVED_SOURCES_DIR/$INPUT_FILE_BASE.generated.swift";
+			script = "sh sources/stencil.sh \"${INPUT_FILE_DIR}/${INPUT_FILE_NAME}\" \"${DERIVED_SOURCES_DIR}/${INPUT_FILE_BASE}.generated.swift\"";
 		};
 /* End PBXBuildRule section */
 

--- a/PlayerControls/resources/DefaultControlsViewController.xib
+++ b/PlayerControls/resources/DefaultControlsViewController.xib
@@ -19,6 +19,7 @@
                 <outlet property="controlsView" destination="fi9-sW-1VX" id="dg0-wz-bBh"/>
                 <outlet property="durationTextLabel" destination="Im0-Vw-2gZ" id="7UT-l7-dfO"/>
                 <outlet property="errorLabel" destination="UtD-cb-Wlb" id="ebo-gb-gDd"/>
+                <outlet property="liveDotLabel" destination="5Hj-Mr-azG" id="4IE-zq-M31"/>
                 <outlet property="liveIndicationView" destination="aUE-Db-Ht9" id="3TF-6f-Ijr"/>
                 <outlet property="liveIndicationViewTitleConstraint" destination="w88-zY-fND" id="bsv-Kb-P0J"/>
                 <outlet property="loadingImageView" destination="ikX-6f-FSq" id="VZj-CY-bUg"/>

--- a/PlayerControls/sources/ContentControlsUIProps.swift
+++ b/PlayerControls/sources/ContentControlsUIProps.swift
@@ -143,8 +143,10 @@ extension DefaultControlsViewController {
             seekbarPositionedAtBottom = {
                 guard let playable = props.player?.item.playable else { return false }
                 let hasNoTitle = playable.title.characters.count == 0
-                let hasNoSubtitles = playable.legible.external?.external.isNone ?? true
-                return hasNoTitle && hasNoSubtitles
+                let hasNoSettings = playable.settings.isHidden
+                let hasNoLiveLabel = playable.live.isHidden
+                let hasNoPipButton = playable.pictureInPictureControl.isUnsupported
+                return hasNoTitle && hasNoSettings && hasNoLiveLabel && hasNoPipButton
             }()
             
             sideBarViewHidden = props.player?.item.playable?.sideBarViewHidden ?? true

--- a/PlayerControls/sources/ContentControlsUIProps.swift
+++ b/PlayerControls/sources/ContentControlsUIProps.swift
@@ -72,6 +72,7 @@ extension DefaultControlsViewController {
         var settingsButtonAction: Action<Void>
         
         var liveIndicationViewIsHidden: Bool
+        var liveDotColor: UIColor?
         
         //swiftlint:disable function_body_length
         //swiftlint:disable cyclomatic_complexity
@@ -215,7 +216,9 @@ extension DefaultControlsViewController {
             
             settingsButtonAction = props.player?.item.playable?.settings.enabled ?? nop
             
-            liveIndicationViewIsHidden = props.player?.item.playable?.isLive ?? true
+            liveIndicationViewIsHidden = props.player?.item.playable?.live.isHidden ?? true
+            
+            liveDotColor = props.player?.item.playable?.live.dotColor
         }
     }
 }

--- a/PlayerControls/sources/ContentControlsViewController.swift
+++ b/PlayerControls/sources/ContentControlsViewController.swift
@@ -53,7 +53,12 @@ extension ContentControlsViewController.Props.Player.Item {
             case replay(Action<Void>)
         }
         
-        public var isLive: Bool = false
+        public var live = Live()
+        public struct Live {
+            public var isHidden = true
+            public var dotColor: UIColor?
+            public init() { }
+        }
         public var seekbar: Seekbar?
         public struct Seekbar {
             public typealias Seconds = UInt

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -50,6 +50,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     
     @IBOutlet private var liveIndicationView: UIView!
     @IBOutlet private var liveIndicationViewTitleConstraint: NSLayoutConstraint!
+    @IBOutlet private var liveDotLabel: UILabel!
     
     @IBOutlet private var visibleControlsSubtitlesConstraint: NSLayoutConstraint!
     @IBOutlet private var invisibleControlsSubtitlesConstraint: NSLayoutConstraint!
@@ -180,7 +181,9 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         
         liveIndicationView.isHidden = uiProps.liveIndicationViewIsHidden
         liveIndicationViewTitleConstraint.isActive = !uiProps.liveIndicationViewIsHidden
+        liveDotLabel.textColor = uiProps.liveDotColor ?? view.tintColor
     }
+    
     //swiftlint:enable function_body_length
     //swiftlint:enable cyclomatic_complexity
     

--- a/PlayerControls/sources/Defaultable.swift
+++ b/PlayerControls/sources/Defaultable.swift
@@ -15,6 +15,7 @@ extension ContentControlsViewController.Props.Player: Defaultable { }
 extension ContentControlsViewController.Props.Player.Item.Controls.Seekbar: Defaultable { }
 extension ContentControlsViewController.Props.Player.Item.Controls.Seekbar.Seeker: Defaultable { }
 extension ContentControlsViewController.Props.Player.Item.Controls.Seekbar.Seeker.State: Defaultable { }
+extension ContentControlsViewController.Props.Player.Item.Controls.Live: Defaultable { }
 extension ContentControlsViewController.Props.Player.Item.Controls.Camera: Defaultable { }
 extension ContentControlsViewController.Props.Player.Item.Controls.Camera.Angles: Defaultable { }
 extension ContentControlsViewController.Props.Player.Item.Controls.Error: Defaultable { }

--- a/PlayerControls/sources/stencil.sh
+++ b/PlayerControls/sources/stencil.sh
@@ -1,0 +1,11 @@
+set -e
+
+if ! which sourcery > /dev/null; then
+    echo "error: Sourcery is missing. Make brew install sourcery."
+    exit 1
+fi
+
+templates=$1
+output=$2
+
+sourcery --sources sources --templates "${templates}" --output "${output}" 


### PR DESCRIPTION
```
playerVC.customizeContentControlsProps = { props in
            guard case .player(let controls) = props else { return props }
            guard case .playable(let content) = controls.item else { return props }
            var newContent = content
            newContent.live.dotColor = .red
            
            return .player(.init {
                $0.playlist = controls.playlist
                $0.item = .playable(newContent)
                })
        }
```

<img width="487" alt="screen shot 2017-09-11 at 6 34 52 pm" src="https://user-images.githubusercontent.com/16276892/30283176-06b9f9d2-9720-11e7-9b69-757f2eff27a8.png">
<img width="487" alt="screen shot 2017-09-11 at 6 34 58 pm" src="https://user-images.githubusercontent.com/16276892/30283166-037362b8-9720-11e7-8da4-a15fbe699cb0.png">