### PR TITLE
Ignore resetTimer on hiddenPaused

### DIFF
--- a/PlayerControls/sources/ControlsVisibilityController.swift
+++ b/PlayerControls/sources/ControlsVisibilityController.swift
@@ -84,6 +84,8 @@ public class ControlsPresentationController {
             
         case .play:
             behavior = CommandWith { [weak self] in self?.hiddenPlaying(by: $0) }
+        
+        case .resetTimer: break
             
         default: fatalError("Unhandled message: \(message)") }
     }


### PR DESCRIPTION
If disable view hiding with `controlsViewHidden` app gets crash on `ControlsPresentationController.hiddenPaused()`. It can be fixed with ignoring `resetTimer` message in `ControlsPresentationController.hiddenPaused()` or redesign `ContentControlsViewController.Props.player` with rewriting logic in `DefaultControlsViewController`.
@AndriiMoskvin @AlexeyDemedetskiy 