### PR TITLE
Added iPhone X layout support programmatically (iOS 8+)

### DIFF
--- a/Demo/Demo/AppDelegate.swift
+++ b/Demo/Demo/AppDelegate.swift
@@ -3,29 +3,97 @@
 import UIKit
 import PlayerControls
 
-func nop() {}
-
 typealias Props = ContentControlsViewController.Props
 func props() -> Props {
-    return Props.player(Props.Player { player in
-        player.item = Props.Player.Item.playable(Props.Player.Item.Controls { controls in
-            controls.title = "Some title very very very very very very very very very long"
-            controls.live.isHidden = true
-            controls.seekbar = .init()
-            controls.playbackAction.pause = nop
-            controls.camera = Props.Player.Item.Controls.Camera()
-            controls.settings = .hidden
-            controls.pictureInPictureControl = .unsupported
-            controls.legible = .`internal`(nil)
-            controls.title = ""
-            controls.airplay = .enabled
-        })
+    return Props.player(
+        DefaultControlsViewController.Props.Player { player in
+            player.playlist = DefaultControlsViewController.Props.Player.Playlist()
+            player.playlist?.next = nop
+            player.playlist?.prev = nop
+            player.item = DefaultControlsViewController.Props.Player.Item.playable(
+                DefaultControlsViewController.Props.Player.Item.Controls { controls in
+                    
+                    controls.title = "Some not very long title"
+                    controls.seekbar = .init()
+                    controls.seekbar?.duration = 3600
+                    controls.seekbar?.currentTime = 1800
+                    controls.seekbar?.progress = 0.5
+                    controls.seekbar?.buffered = 0.75
+                    controls.seekbar?.seeker.seekTo = nop()
+                    controls.seekbar?.seeker.state.start = nop()
+                    
+                    controls.playbackAction.pause = nop
+                    
+                    controls.live.isHidden = true
+                    controls.camera = DefaultControlsViewController.Props.Player.Item.Controls.Camera()
+                    
+                    controls.camera?.angles.horizontal = 3.14
+                    controls.camera?.angles.vertical = 3.14
+                    controls.camera?.moveTo = nop()
+                    
+                    controls.sideBarViewHidden = false
+                    
+                    controls.settings = .enabled(nop())
+                    controls.pictureInPictureControl = .possible(nop())
+                    controls.airplay = .enabled
+                    
+                    controls.legible = .external(external: .available(state: .active(text: "Don't you ever give up")), control: DefaultControlsViewController.Props.Player.Item.Controls.MediaGroupControl())
+            })
     })
+}
+
+func sideProps() -> [SideBarView.ButtonProps]{
+    
+    let shareIcons = SideBarView.ButtonProps.Icons(
+        normal: UIImage(named: "icon-share", in: Bundle(identifier: "com.aol.one.PlayerControls"), compatibleWith: nil)!,
+        selected: nil,
+        highlighted: UIImage(named: "icon-share-active", in: Bundle(identifier: "com.aol.one.PlayerControls"), compatibleWith: nil))
+    
+    let share = SideBarView.ButtonProps(
+        isEnabled: true,
+        isSelected: false,
+        icons: shareIcons,
+        handler: {})
+    
+    let addIcon = SideBarView.ButtonProps.Icons(
+        normal: UIImage(named: "icon-add", in: Bundle(identifier: "com.aol.one.PlayerControls"), compatibleWith: nil)!,
+        selected: nil,
+        highlighted: UIImage(named: "icon-add-active", in: Bundle(identifier: "com.aol.one.PlayerControls"), compatibleWith: nil))
+    
+    let add = SideBarView.ButtonProps(
+        isEnabled: true,
+        isSelected: false,
+        icons: addIcon,
+        handler: {})
+    
+    let favoriteIcon = SideBarView.ButtonProps.Icons(
+        normal: UIImage(named: "icon-fav", in: Bundle(identifier: "com.aol.one.PlayerControls"), compatibleWith: nil)!,
+        selected: nil,
+        highlighted: UIImage(named: "icon-fav-active", in: Bundle(identifier: "com.aol.one.PlayerControls"), compatibleWith: nil)))
+    
+    let favorite = SideBarView.ButtonProps(
+        isEnabled: true,
+        isSelected: false,
+        icons: favoriteIcon,
+        handler: {})
+    
+    let laterIcon = SideBarView.ButtonProps.Icons(
+        normal: UIImage(named: "icon-later", in: Bundle(identifier: "com.aol.one.PlayerControls"), compatibleWith: nil)!,
+        selected: nil,
+        highlighted: UIImage(named: "icon-later-active", in: Bundle(identifier: "com.aol.one.PlayerControls"), compatibleWith: nil))
+    
+    let later = SideBarView.ButtonProps(
+        isEnabled: true,
+        isSelected: false,
+        icons: laterIcon,
+        handler: {})
+    
+    return [later, favorite, share, add]
 }
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
+    
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
@@ -35,6 +103,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         vc.view.tintColor = .blue
         vc.props = props()
         
+        vc.sidebarProps = sideProps()
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = vc
         window?.makeKeyAndVisible()
@@ -43,3 +112,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 }
 
+func nop<T>() -> Action<T> {
+    return { _ in }
+}
+
+func nop<T>(t: T) { }
+
+func nop() { }

--- a/PlayerControls/resources/DefaultControlsViewController.xib
+++ b/PlayerControls/resources/DefaultControlsViewController.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina3_5" orientation="landscape">
+    <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -57,11 +57,11 @@
             </connections>
         </tapGestureRecognizer>
         <view contentMode="scaleToFill" id="rFH-6N-3gH">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="320"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SEd-qf-YJr" userLabel="Subtitles">
-                    <rect key="frame" x="206" y="167" width="68" height="43"/>
+                    <rect key="frame" x="153.5" y="514" width="68" height="43"/>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.34999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                     <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <string key="text">Subtitles
@@ -71,19 +71,19 @@ Subtitles</string>
                     <nil key="highlightedColor"/>
                 </label>
                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="NKq-bU-tvG">
-                    <rect key="frame" x="0.0" y="0.0" width="480" height="320"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                 </imageView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fi9-sW-1VX" userLabel="Controls view">
-                    <rect key="frame" x="0.0" y="0.0" width="480" height="320"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <subviews>
                         <view alpha="0.29999999999999999" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="m54-Yx-R7K" userLabel="Shadow View">
-                            <rect key="frame" x="0.0" y="0.0" width="480" height="320"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
                         <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="icon-loading" translatesAutoresizingMaskIntoConstraints="NO" id="ikX-6f-FSq">
-                            <rect key="frame" x="193" y="113" width="95" height="95"/>
+                            <rect key="frame" x="140.5" y="286.5" width="95" height="95"/>
                         </imageView>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="l0O-oR-0Rg">
                             <rect key="frame" x="10" y="20" width="30" height="30"/>
@@ -96,7 +96,7 @@ Subtitles</string>
                             <rect key="frame" x="10" y="20" width="30" height="30"/>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="98K-SA-Pdv">
-                            <rect key="frame" x="15" y="263" width="35" height="43"/>
+                            <rect key="frame" x="15" y="610" width="35" height="43"/>
                             <string key="text">Title
 Title</string>
                             <fontDescription key="fontDescription" type="system" pointSize="18"/>
@@ -104,7 +104,7 @@ Title</string>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wVE-Q8-zOG">
-                            <rect key="frame" x="193" y="113" width="95" height="95"/>
+                            <rect key="frame" x="140.5" y="286.5" width="95" height="95"/>
                             <state key="normal" image="icon-replay"/>
                             <state key="highlighted" image="icon-replay-glow"/>
                             <connections>
@@ -112,7 +112,7 @@ Title</string>
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U8A-X2-cyf" userLabel="Play Button">
-                            <rect key="frame" x="193" y="113" width="95" height="95"/>
+                            <rect key="frame" x="140.5" y="286.5" width="95" height="95"/>
                             <state key="normal" image="icon-play"/>
                             <state key="highlighted" image="icon-play-glow"/>
                             <connections>
@@ -120,7 +120,7 @@ Title</string>
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KeK-cX-xXB" userLabel="Pause Button">
-                            <rect key="frame" x="193" y="113" width="95" height="95"/>
+                            <rect key="frame" x="140.5" y="286.5" width="95" height="95"/>
                             <state key="normal" image="icon-pause"/>
                             <state key="highlighted" image="icon-pause-glow"/>
                             <connections>
@@ -128,7 +128,7 @@ Title</string>
                             </connections>
                         </button>
                         <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ida-wI-kAP" userLabel="Next">
-                            <rect key="frame" x="346" y="145" width="22" height="32"/>
+                            <rect key="frame" x="293.5" y="318.5" width="22" height="32"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <inset key="contentEdgeInsets" minX="0.0" minY="5" maxX="5" maxY="5"/>
                             <state key="normal" image="icon-forward"/>
@@ -138,7 +138,7 @@ Title</string>
                             </connections>
                         </button>
                         <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="73i-r1-qKj" userLabel="Prev">
-                            <rect key="frame" x="112" y="145" width="23" height="32"/>
+                            <rect key="frame" x="59.5" y="318.5" width="23" height="32"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <inset key="contentEdgeInsets" minX="5" minY="5" maxX="0.0" maxY="5"/>
                             <state key="normal" image="icon-backward"/>
@@ -148,7 +148,7 @@ Title</string>
                             </connections>
                         </button>
                         <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="djN-u7-nkt" userLabel="10 sec forward">
-                            <rect key="frame" x="294" y="140" width="42" height="42"/>
+                            <rect key="frame" x="241.5" y="313.5" width="42" height="42"/>
                             <state key="normal" image="icon-10-sec"/>
                             <state key="highlighted" image="icon-10-sec-active"/>
                             <connections>
@@ -156,7 +156,7 @@ Title</string>
                             </connections>
                         </button>
                         <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cNh-R2-LdG" userLabel="10 sec backward">
-                            <rect key="frame" x="145" y="140" width="42" height="42"/>
+                            <rect key="frame" x="92.5" y="313.5" width="42" height="42"/>
                             <state key="normal" image="icon-10-sec"/>
                             <state key="highlighted" image="icon-10-sec-active"/>
                             <connections>
@@ -164,7 +164,7 @@ Title</string>
                             </connections>
                         </button>
                         <button hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tGV-rG-prj" userLabel="PiP">
-                            <rect key="frame" x="393" y="267" width="32" height="32"/>
+                            <rect key="frame" x="288" y="614" width="32" height="32"/>
                             <state key="normal" image="icon-pip"/>
                             <state key="highlighted" image="icon-pip-active"/>
                             <connections>
@@ -172,7 +172,7 @@ Title</string>
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ddy-Jb-aVD">
-                            <rect key="frame" x="299" y="267" width="32" height="32"/>
+                            <rect key="frame" x="194" y="614" width="32" height="32"/>
                             <state key="normal" image="icon-sub">
                                 <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </state>
@@ -182,7 +182,7 @@ Title</string>
                             </connections>
                         </button>
                         <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="72o-zQ-Neb" customClass="AirPlayView" customModule="PlayerControls" customModuleProvider="target">
-                            <rect key="frame" x="346" y="267" width="32" height="32"/>
+                            <rect key="frame" x="241" y="614" width="32" height="32"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="32" id="kVT-H7-Wgy"/>
@@ -190,18 +190,18 @@ Title</string>
                             </constraints>
                         </view>
                         <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Im0-Vw-2gZ">
-                            <rect key="frame" x="431" y="257" width="32" height="14"/>
+                            <rect key="frame" x="326" y="597" width="32" height="14"/>
                             <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                             <color key="textColor" red="0.81568627450980391" green="0.81568627450980391" blue="0.81568627450980391" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" placeholderIntrinsicWidth="30" placeholderIntrinsicHeight="infinite" translatesAutoresizingMaskIntoConstraints="NO" id="Uc8-v7-96O" customClass="SideBarView" customModule="PlayerControls" customModuleProvider="target">
-                            <rect key="frame" x="450" y="0.0" width="30" height="213"/>
+                            <rect key="frame" x="345" y="0.0" width="30" height="550"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
                         <view hidden="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="57" translatesAutoresizingMaskIntoConstraints="NO" id="fAO-vH-cgi" customClass="SeekerControlView" customModule="PlayerControls" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="203" width="480" height="54"/>
+                            <rect key="frame" x="0.0" y="540" width="375" height="57"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="number" keyPath="height">
@@ -397,19 +397,19 @@ Title</string>
                     </variation>
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This video is playing on Apple TV" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kPK-Sh-8jh">
-                    <rect key="frame" x="127" y="75" width="226.5" height="18"/>
+                    <rect key="frame" x="74.5" y="248" width="226" height="18"/>
                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UtD-cb-Wlb" userLabel="Error">
-                    <rect key="frame" x="240" y="100" width="0.0" height="0.0"/>
+                    <rect key="frame" x="187.5" y="273.5" width="0.0" height="0.0"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IVo-gm-8qs">
-                    <rect key="frame" x="193" y="113" width="95" height="95"/>
+                    <rect key="frame" x="140" y="286" width="95" height="95"/>
                     <state key="normal" image="icon-replay"/>
                     <connections>
                         <action selector="retry" destination="-1" eventType="touchUpInside" id="tme-iX-huy"/>
@@ -443,9 +443,9 @@ Title</string>
             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="NKq-bU-tvG" firstAttribute="top" secondItem="rFH-6N-3gH" secondAttribute="top" id="24r-Hq-M3g"/>
-                <constraint firstAttribute="bottom" secondItem="fi9-sW-1VX" secondAttribute="bottom" id="33F-58-Fc1"/>
+                <constraint firstAttribute="bottom" secondItem="fi9-sW-1VX" secondAttribute="bottom" priority="751" id="33F-58-Fc1"/>
                 <constraint firstItem="IVo-gm-8qs" firstAttribute="top" secondItem="kPK-Sh-8jh" secondAttribute="bottom" constant="20" id="7Wz-dr-n9W"/>
-                <constraint firstItem="aUE-Db-Ht9" firstAttribute="top" secondItem="rFH-6N-3gH" secondAttribute="top" constant="20" id="8xl-GB-75a"/>
+                <constraint firstItem="aUE-Db-Ht9" firstAttribute="top" secondItem="rFH-6N-3gH" secondAttribute="top" priority="999" constant="20" id="8xl-GB-75a"/>
                 <constraint firstItem="Uc8-v7-96O" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="UtD-cb-Wlb" secondAttribute="trailing" constant="10" id="FtY-J6-Kdm"/>
                 <constraint firstItem="UtD-cb-Wlb" firstAttribute="centerY" secondItem="fi9-sW-1VX" secondAttribute="centerY" constant="-60" id="Jcc-XU-IcT">
                     <variation key="heightClass=regular-widthClass=regular" constant="-120"/>
@@ -455,15 +455,15 @@ Title</string>
                 <constraint firstAttribute="bottom" secondItem="NKq-bU-tvG" secondAttribute="bottom" id="Vog-pm-tOS"/>
                 <constraint firstItem="IVo-gm-8qs" firstAttribute="centerX" secondItem="rFH-6N-3gH" secondAttribute="centerX" id="ZsG-TS-eKR"/>
                 <constraint firstItem="NKq-bU-tvG" firstAttribute="leading" secondItem="rFH-6N-3gH" secondAttribute="leading" id="cUc-Ko-vsy"/>
-                <constraint firstItem="fi9-sW-1VX" firstAttribute="top" secondItem="rFH-6N-3gH" secondAttribute="top" id="cbb-BO-G5L"/>
+                <constraint firstItem="fi9-sW-1VX" firstAttribute="top" secondItem="rFH-6N-3gH" secondAttribute="top" priority="751" id="cbb-BO-G5L"/>
                 <constraint firstItem="UtD-cb-Wlb" firstAttribute="centerX" secondItem="rFH-6N-3gH" secondAttribute="centerX" id="daT-2G-R8Z"/>
-                <constraint firstAttribute="trailing" secondItem="fi9-sW-1VX" secondAttribute="trailing" id="eNx-qY-amb"/>
+                <constraint firstAttribute="trailing" secondItem="fi9-sW-1VX" secondAttribute="trailing" priority="750" id="eNx-qY-amb"/>
                 <constraint firstItem="IVo-gm-8qs" firstAttribute="centerY" secondItem="rFH-6N-3gH" secondAttribute="centerY" constant="0.16666666666668561" id="g2S-a8-EXu"/>
                 <constraint firstAttribute="bottom" secondItem="SEd-qf-YJr" secondAttribute="bottom" constant="110" id="gK7-AG-J2d"/>
                 <constraint firstAttribute="trailing" secondItem="NKq-bU-tvG" secondAttribute="trailing" id="giY-J7-3C9"/>
-                <constraint firstItem="aUE-Db-Ht9" firstAttribute="leading" secondItem="rFH-6N-3gH" secondAttribute="leading" constant="10" id="mZh-yz-9m2"/>
+                <constraint firstItem="aUE-Db-Ht9" firstAttribute="leading" secondItem="rFH-6N-3gH" secondAttribute="leading" priority="999" constant="10" id="mZh-yz-9m2"/>
                 <constraint firstItem="UtD-cb-Wlb" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="rFH-6N-3gH" secondAttribute="leading" constant="40" id="ute-YD-JsE"/>
-                <constraint firstItem="fi9-sW-1VX" firstAttribute="leading" secondItem="rFH-6N-3gH" secondAttribute="leading" id="vK8-8v-dJz"/>
+                <constraint firstItem="fi9-sW-1VX" firstAttribute="leading" secondItem="rFH-6N-3gH" secondAttribute="leading" priority="750" id="vK8-8v-dJz"/>
             </constraints>
             <connections>
                 <outletCollection property="gestureRecognizers" destination="ydI-nT-cAb" appends="YES" id="w9x-Nr-aVL"/>

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -205,6 +205,67 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         airPlayView.isHidden = uiProps.airplayButtonHidden
     }
     
+    //Code below makes expected layout on all devices, including iPhone X without changes in interface in xib file, which can be made only without iOS 8 support.
+    public override func viewDidLayoutSubviews() {
+        
+        super.viewDidLayoutSubviews()
+        let statusBarSpacing: CGFloat = 20.0
+        
+        if #available(iOS 11, *) {
+            let guide = view.safeAreaLayoutGuide
+            controlsView.topAnchor.constraint(equalTo: guide.topAnchor).isActive = true
+            controlsView.bottomAnchor.constraint(equalTo: guide.bottomAnchor).isActive = true
+            controlsView.trailingAnchor.constraint(equalTo: guide.trailingAnchor).isActive = true
+            controlsView.leadingAnchor.constraint(equalTo: guide.leadingAnchor).isActive = true
+            
+            shadowView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+            shadowView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+            shadowView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+            shadowView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+            
+            liveIndicationView.topAnchor.constraint(equalTo: guide.topAnchor, constant: 10).isActive = true
+            liveIndicationView.leadingAnchor.constraint(equalTo: guide.leadingAnchor, constant: 10).isActive = true
+            
+            visibleControlsSubtitlesConstraint.constant = controlsView.isHidden
+                ? 30 + view.safeAreaInsets.bottom
+                : 110 + view.safeAreaInsets.bottom
+        } else if #available(iOS 9, *) {
+            controlsView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+            controlsView.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
+            controlsView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
+            controlsView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+            
+            shadowView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        } else {
+            NSLayoutConstraint(item: controlsView, attribute: .top, relatedBy: .equal, toItem: view,
+                               attribute: .top, multiplier: 1, constant: 0).isActive = true
+            NSLayoutConstraint(item: controlsView, attribute: .bottom, relatedBy: .equal, toItem: view,
+                               attribute: .bottom, multiplier: 1, constant: 0).isActive = true
+            NSLayoutConstraint(item: controlsView, attribute: .leading, relatedBy: .equal, toItem: view,
+                               attribute: .leading, multiplier: 1, constant: 0).isActive = true
+            NSLayoutConstraint(item: controlsView, attribute: .trailing, relatedBy: .equal, toItem: view,
+                               attribute: .trailing, multiplier: 1, constant: 0).isActive = true
+            
+            NSLayoutConstraint(item: shadowView, attribute: .top, relatedBy: .equal, toItem: view,
+                               attribute: .top, multiplier: 1, constant: 0).isActive = true
+            
+            NSLayoutConstraint(item: liveIndicationView, attribute: .top, relatedBy: .equal, toItem: view,
+                               attribute: .top, multiplier: 1, constant: statusBarSpacing).isActive = true
+        }
+        
+    }
+    
+    ///Method that hides or shows iPhone X home indicator based on controlsView hidden status.
+    @available(iOS 11.0, *)
+    override public func prefersHomeIndicatorAutoHidden() -> Bool
+    {
+        if controlsView.isHidden {
+            return true
+        } else {
+            return false
+        }
+    }
+    
     //swiftlint:enable function_body_length
     //swiftlint:enable cyclomatic_complexity
     
@@ -231,7 +292,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     
     func updateVisibilityController( //swiftlint:disable:this cyclomatic_complexity
         from old: ContentControlsViewController.Props,
-             to new: ContentControlsViewController.Props) {
+        to new: ContentControlsViewController.Props) {
         
         func isVideoPlaying(for props: ContentControlsViewController.Props) -> Bool {
             guard case .player(let player) = props else { return false }
@@ -281,7 +342,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     
     @IBAction private func pauseButtonTouched() {
         uiProps.pauseButtonAction()
-		onUserInteraction?()
+        onUserInteraction?()
     }
     
     @IBAction private func replayButtonTouched() {
@@ -301,17 +362,17 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     
     private func startSeek(from progress: CGFloat) {
         uiProps.startSeekAction(.init(progress))
-		onUserInteraction?()
+        onUserInteraction?()
     }
     
     private func updateSeek(to progress: CGFloat) {
         uiProps.updateSeekAction(.init(progress))
-		onUserInteraction?()
+        onUserInteraction?()
     }
     
     private func stopSeek(at progress: CGFloat) {
         uiProps.stopSeekAction(.init(progress))
-		onUserInteraction?()
+        onUserInteraction?()
     }
     
     @IBAction private func seekForwardButtonTouched() {


### PR DESCRIPTION
This pull-request is for the same purpose as the previous one (#46) but it should be merged first. The reason is that the iPhone X support was realized programmatically and it has only similar changes in .xib file of default controls, which are the changed priorities of some constraints. It was done to create our own constrains in code, that will be called according to the iOS version and theirs priorities will be the highest. 

For iOS 11, there were added new constraints for our controls view. Now his edges are equal to safe area layout guide edges. But the shadow view is a subview of controls view, so it was stretched to the borders of the main view manually. Live and Subtitles labels are also related to safe area.
Platforms with lower iOS are not able to use safe area, but all of the screens are the same and there is no problem 
For iOS 10 and lower platforms there have to be manual constraints too, because the UI may behave differently because of changes in priorities. 
There may be a much easier way of doing this, ~~ like refusal of iOS 8 support~~ but I could find only this one, especially because it is temporally, until we move on Swift 4.

Also important thing that definitely has to be in our controls is Auto-Hide for iPhone X Home indicator. It has default method prefersHomeIndicatorAutoHidden, that relies on controlsHidden status.

And the last one, there is an updated AppDelegate, that covers all of the possible controls for our Demo. It could be much better to have them all shown to simplify setting up.

<img width="735" alt="screen" src="https://user-images.githubusercontent.com/31652265/33177375-12fe9ffc-d06b-11e7-9084-1877210baa73.png"><img width="835" alt="screen 4x" src="https://user-images.githubusercontent.com/31652265/33177378-135f338a-d06b-11e7-9a30-989b92ca5386.png">
<img width="335" alt="screen 3x" src="https://user-images.githubusercontent.com/31652265/33177377-133ad01c-d06b-11e7-86b7-6b3ceb46fabf.png"><img width="335" alt="screen 2x" src="https://user-images.githubusercontent.com/31652265/33177376-131b640c-d06b-11e7-89cc-f9145af08534.png">
