### PR TITLE
AirPlay displaying only with available wireless routes

### DIFF
--- a/PlayerControls/sources/AirPlayView.swift
+++ b/PlayerControls/sources/AirPlayView.swift
@@ -35,7 +35,7 @@ public final class AirPlayView: UIView {
     var props: Props = Props.empty {
         didSet { setNeedsLayout() }
     }
-    private let volumeView = MPVolumeView()
+    public let volumeView = MPVolumeView()
     
     public override func awakeFromNib() {
         super.awakeFromNib()

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -78,6 +78,15 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         }
     }
     
+    public override func viewWillAppear(_ animated: Bool) {
+        setupAirPlayCurrentVisibility()
+        NotificationCenter.default.addObserver(self, selector: #selector(setupAirPlayCurrentVisibility), name: .MPVolumeViewWirelessRoutesAvailableDidChange, object: nil)
+    }
+    
+    public override func viewWillDisappear(_ animated: Bool) {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         seekerView.callbacks.onDragStarted = { [unowned self] value in
@@ -146,9 +155,8 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         visibleControlsSubtitlesConstraint.constant = uiProps.controlsViewHidden ? 30 : 110
         airplayPipTrailingConstrains.isActive = !uiProps.pipButtonHidden
         airplayEdgeTrailingConstrains.isActive = uiProps.pipButtonHidden
-        subtitlesAirplayTrailingConstrains.isActive = !uiProps.airplayButtonHidden 
-        subtitlesEdgeTrailingConstrains.isActive = uiProps.airplayButtonHidden && uiProps.pipButtonHidden
-        subtitlesPipTrailingConstrains.isActive = uiProps.airplayButtonHidden
+
+        setupAirPlayCurrentVisibility()
         
         thumbnailImageView.isHidden = uiProps.thumbnailImageViewHidden
         
@@ -272,6 +280,15 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         onTapEvent = visibilityController.tap
         onPlayEvent = visibilityController.play
         onPauseEvent = visibilityController.pause
+    }
+    
+    func setupAirPlayCurrentVisibility() {
+        airPlayView.isHidden = !uiProps.airplayButtonHidden && airPlayView.volumeView.areWirelessRoutesAvailable
+            ? false
+            : true
+        subtitlesAirplayTrailingConstrains.isActive = !airPlayView.isHidden
+        subtitlesEdgeTrailingConstrains.isActive = airPlayView.isHidden && uiProps.pipButtonHidden
+        subtitlesPipTrailingConstrains.isActive = airPlayView.isHidden
     }
     
     @IBAction private func playButtonTouched() {


### PR DESCRIPTION
###  Improvements of AirPlay displaying. 
The problem is that when AirPlay is enabled in UIProps, but is not available on the device in the moment (no wireless routes or no connection) the AirPlayView didn't disappear. 
It's not so critical, but this is how it looks like when AirPlay is not available.
<img width="500" alt="airplaybug" src="https://user-images.githubusercontent.com/31652265/33267935-efc71bce-d383-11e7-89ce-81e2c883c673.png">
It is caused by **_MPVolumeView_**, that disappears from AirPlayView, when there is no routes for video translating. 
Fixing this issue is adding observer of MPVolumeView variable called **_areWirelesRoutesAvailable_**. It's actually already has its own observer named as **_MPVolumeViewWirelessRoutesAvailableDidChange_**, so I added this notification to default Notification Center and when the value of this variable changes, the **_setupAirPlayCurrentVisibility_** method will be called. This method will set up necessary state for airplay's view (hidden or not) and according to its current visibility, it will manage the state of constraints.

Now on much smaller devices there'll be much more place for title in portrait mode and it will have much more acceptable view.

<img width="300" alt="airplaybug" src="https://user-images.githubusercontent.com/31652265/33268594-78796524-d386-11e7-8275-ed4516feb1c0.png">

Please note, that in this case you won't see an AirPlayView and you won't be able to interact with it, if you launch demo on iOS Simulator (unless Simulator will be able to find Apple TV or another wireless route).