### PR TITLE
Modified EnumPrisma.stencil for extending only necessary enums

### DIFF
--- a/Demo/Demo/AppDelegate.swift
+++ b/Demo/Demo/AppDelegate.swift
@@ -12,7 +12,7 @@ func props() -> Props {
             controls.title = "Some title very very very very very very very very very long"
             controls.live.isHidden = true
             controls.seekbar = .init()
-            controls.playbackAction.pause = nop
+            controls.playbackAction = .pause(nop)
             controls.camera = Props.Player.Item.Controls.Camera()
             controls.settings = .hidden
             controls.pictureInPictureControl = .unsupported

--- a/PlayerControls/sources/AdVideoControls.swift
+++ b/PlayerControls/sources/AdVideoControls.swift
@@ -75,7 +75,7 @@ public final class AdVideoControls: UIViewController {
         public let isLoading: Bool
         public let airplayActiveViewHidden: Bool
         
-        public enum MainAction {
+        public enum MainAction: GeneratePrism {
             case play(Action<Void>)
             case pause(Action<Void>)
         }

--- a/PlayerControls/sources/AdVideoControls.swift
+++ b/PlayerControls/sources/AdVideoControls.swift
@@ -75,7 +75,7 @@ public final class AdVideoControls: UIViewController {
         public let isLoading: Bool
         public let airplayActiveViewHidden: Bool
         
-        public enum MainAction: GeneratePrism {
+        public enum MainAction: Prism {
             case play(Action<Void>)
             case pause(Action<Void>)
         }

--- a/PlayerControls/sources/ContentControlsViewController.swift
+++ b/PlayerControls/sources/ContentControlsViewController.swift
@@ -2,7 +2,9 @@
 
 import Foundation
 
-public protocol GeneratePrism {}
+///Generate prism for confirmed enum 
+public protocol Prism {}
+
 /// Base class for implementing custom content
 /// video controls.
 open class ContentControlsViewController: UIViewController {
@@ -15,7 +17,7 @@ open class ContentControlsViewController: UIViewController {
         }
     }
     
-    public enum Props: GeneratePrism {
+    public enum Props: Prism {
         case noPlayer
 
         case player(Player)
@@ -31,7 +33,7 @@ open class ContentControlsViewController: UIViewController {
             }
 
             public var item = Item.nonplayable("")
-            public enum Item: GeneratePrism {
+            public enum Item: Prism {
                 case playable(Controls)
                 case nonplayable(String)
             }
@@ -47,7 +49,7 @@ extension ContentControlsViewController.Props.Player.Item {
         public var loading = false
         
         public var playbackAction: Playback = .none
-        public enum Playback: GeneratePrism {
+        public enum Playback: Prism {
             case none
             case play(Action<Void>)
             case pause(Action<Void>)
@@ -108,7 +110,7 @@ extension ContentControlsViewController.Props.Player.Item {
         
         /// URL or UIImage for the thumbnail.
         public var thumbnail: Thumbnail?
-        public enum Thumbnail: GeneratePrism {
+        public enum Thumbnail: Prism {
             case url(URL) //swiftlint:disable:this type_name
             case image(UIImage)
         }
@@ -123,21 +125,21 @@ extension ContentControlsViewController.Props.Player.Item {
         }
         
         public var pictureInPictureControl: PictureInPictureControl = .unsupported
-        public enum PictureInPictureControl: GeneratePrism {
+        public enum PictureInPictureControl: Prism {
             case unsupported
             case impossible
             case possible(Action<Void>)
         }
         
-        public enum Subtitles: GeneratePrism {
+        public enum Subtitles: Prism {
             case `internal`(MediaGroupControl?)
             case external(external: External, control: MediaGroupControl)
             
-            public enum External: GeneratePrism {
+            public enum External: Prism {
                 case none
                 case unavailable
                 case available(state: State)
-                public enum State: GeneratePrism {
+                public enum State: Prism {
                     case active(text: String?), loading, inactive, error
                 }
             }
@@ -158,14 +160,14 @@ extension ContentControlsViewController.Props.Player.Item {
         public var legible: Subtitles = .`internal`(nil)
         public var audible: MediaGroupControl?
         
-        public enum Settings: GeneratePrism {
+        public enum Settings: Prism {
             case hidden
             case disabled
             case enabled(Action<Void>)
         }
         public var settings: Settings = .disabled
         
-        public enum AirPlay: GeneratePrism {
+        public enum AirPlay: Prism {
             case hidden
             case enabled
             case active

--- a/PlayerControls/sources/ContentControlsViewController.swift
+++ b/PlayerControls/sources/ContentControlsViewController.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 
+public protocol GeneratePrism {}
 /// Base class for implementing custom content
 /// video controls.
 open class ContentControlsViewController: UIViewController {
@@ -14,7 +15,7 @@ open class ContentControlsViewController: UIViewController {
         }
     }
     
-    public enum Props {
+    public enum Props: GeneratePrism {
         case noPlayer
 
         case player(Player)
@@ -30,7 +31,7 @@ open class ContentControlsViewController: UIViewController {
             }
 
             public var item = Item.nonplayable("")
-            public enum Item {
+            public enum Item: GeneratePrism {
                 case playable(Controls)
                 case nonplayable(String)
             }
@@ -46,7 +47,7 @@ extension ContentControlsViewController.Props.Player.Item {
         public var loading = false
         
         public var playbackAction: Playback = .none
-        public enum Playback {
+        public enum Playback: GeneratePrism {
             case none
             case play(Action<Void>)
             case pause(Action<Void>)
@@ -107,7 +108,7 @@ extension ContentControlsViewController.Props.Player.Item {
         
         /// URL or UIImage for the thumbnail.
         public var thumbnail: Thumbnail?
-        public enum Thumbnail {
+        public enum Thumbnail: GeneratePrism {
             case url(URL) //swiftlint:disable:this type_name
             case image(UIImage)
         }
@@ -122,21 +123,21 @@ extension ContentControlsViewController.Props.Player.Item {
         }
         
         public var pictureInPictureControl: PictureInPictureControl = .unsupported
-        public enum PictureInPictureControl {
+        public enum PictureInPictureControl: GeneratePrism {
             case unsupported
             case impossible
             case possible(Action<Void>)
         }
         
-        public enum Subtitles {
+        public enum Subtitles: GeneratePrism {
             case `internal`(MediaGroupControl?)
             case external(external: External, control: MediaGroupControl)
             
-            public enum External {
+            public enum External: GeneratePrism {
                 case none
                 case unavailable
                 case available(state: State)
-                public enum State {
+                public enum State: GeneratePrism {
                     case active(text: String?), loading, inactive, error
                 }
             }
@@ -157,14 +158,14 @@ extension ContentControlsViewController.Props.Player.Item {
         public var legible: Subtitles = .`internal`(nil)
         public var audible: MediaGroupControl?
         
-        public enum Settings {
+        public enum Settings: GeneratePrism {
             case hidden
             case disabled
             case enabled(Action<Void>)
         }
         public var settings: Settings = .disabled
         
-        public enum AirPlay {
+        public enum AirPlay: GeneratePrism {
             case hidden
             case enabled
             case active

--- a/PlayerControls/templates/EnumPrism.stencil
+++ b/PlayerControls/templates/EnumPrism.stencil
@@ -46,34 +46,21 @@ import Foundation
         @available(*, unavailable, message:"Optional associated value is not supported yet")
     {%endif%}
     public var {{case.name}}: {% if case.associatedValues.all.count > 1 %}{% call associatedValueVarMultiType case %}{% else %}{% call associatedValueVarUnitType case %}{% endif %} {
-        get {
             guard case let .{{ case.name }}({{ case.name }}) = self else { return nil }
             return {{case.name}}
-        }
-        set {
-            guard let newValue = newValue else { fatalError("Setting nil value forbidden") }
-            /*Set self from the case has associated value or not*/
-            self = .{{ case.name }}({% if case.associatedValues.all.count > 1 %}{% call associatedValueVarMultiSet case newValue %}{% else %}{% call associatedValueVarUnitSet case newValue %}{% endif %})
-        }
     }
 {% endmacro %}
 
 /*Creates Bool var with given simple case*/
 {% macro simpleVar case %}
     public var is{{ case.name|upperFirst }}: Bool {
-        get {
             guard case .{{ case.name }} = self else { return false }
             return true
-        }
-        set {
-            guard newValue else { fatalError("Setting false value forbidden") }
-            self = .{{ case.name }}
-        }
     }
 {% endmacro %}
 
 /*For each public enum with cases count > 0 is created extension with cases' prism vars*/
-{% for enum in types.enums where enum.cases.all.count > 0 and not enum.accessLevel == 'private' %}
+{% for enum in types.implementing.GeneratePrism|enum   %}
     public extension {{ enum.name }} {
         {% for case in enum.cases %}
             {% if case.hasAssociatedValue %}

--- a/PlayerControls/templates/EnumPrism.stencil
+++ b/PlayerControls/templates/EnumPrism.stencil
@@ -46,21 +46,21 @@ import Foundation
         @available(*, unavailable, message:"Optional associated value is not supported yet")
     {%endif%}
     public var {{case.name}}: {% if case.associatedValues.all.count > 1 %}{% call associatedValueVarMultiType case %}{% else %}{% call associatedValueVarUnitType case %}{% endif %} {
-            guard case let .{{ case.name }}({{ case.name }}) = self else { return nil }
-            return {{case.name}}
+        guard case let .{{ case.name }}({{ case.name }}) = self else { return nil }
+        return {{case.name}}
     }
 {% endmacro %}
 
 /*Creates Bool var with given simple case*/
 {% macro simpleVar case %}
     public var is{{ case.name|upperFirst }}: Bool {
-            guard case .{{ case.name }} = self else { return false }
-            return true
+        guard case .{{ case.name }} = self else { return false }
+        return true
     }
 {% endmacro %}
 
 /*For each public enum with cases count > 0 is created extension with cases' prism vars*/
-{% for enum in types.implementing.GeneratePrism|enum   %}
+{% for enum in types.implementing.Prism|enum %}
     public extension {{ enum.name }} {
         {% for case in enum.cases %}
             {% if case.hasAssociatedValue %}


### PR DESCRIPTION
Implemented  `public protocol GeneratePrism {}` for enums which needs to be extended by EnumPrism. In EnumPrism.stencil I've deleted setters and changed `for enum in types.enums where enum.cases.all.count > 0 and not enum.accessLevel == 'private'` to `for enum in types.implementing.GeneratePrism|enum`. 
Now, all enums marked `GeneratePrism` are extending by EnumPrism