### PR TITLE
Added Command as a replacement for Actions

### DIFF
--- a/Demo/Demo/AppDelegate.swift
+++ b/Demo/Demo/AppDelegate.swift
@@ -3,8 +3,6 @@
 import UIKit
 import PlayerControls
 
-func nop() {}
-
 typealias Props = ContentControlsViewController.Props
 func props() -> Props {
     return Props.player(Props.Player { player in

--- a/Demo/Demo/AppDelegate.swift
+++ b/Demo/Demo/AppDelegate.swift
@@ -12,7 +12,7 @@ func props() -> Props {
             controls.title = "Some title very very very very very very very very very long"
             controls.live.isHidden = true
             controls.seekbar = .init()
-            controls.playbackAction = .pause(nop)
+            controls.playbackAction = .pause(.nop)
             controls.camera = Props.Player.Item.Controls.Camera()
             controls.settings = .hidden
             controls.pictureInPictureControl = .unsupported

--- a/PlayerControls/PlayerControls.xcodeproj/project.pbxproj
+++ b/PlayerControls/PlayerControls.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0696270D1FD188A50098494A /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0696270C1FD188A50098494A /* Command.swift */; };
 		50582F6C1E65C64B00B18908 /* ContentControlsUIProps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50582F671E65C64B00B18908 /* ContentControlsUIProps.swift */; };
 		50582F6E1E65C64B00B18908 /* ContentControlsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50582F691E65C64B00B18908 /* ContentControlsViewController.swift */; };
 		50582F6F1E65C64B00B18908 /* DefaultControlsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50582F6A1E65C64B00B18908 /* DefaultControlsViewController.swift */; };
@@ -67,6 +68,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0696270C1FD188A50098494A /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		50582F5B1E65C41900B18908 /* PlayerControls.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PlayerControls.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		50582F5F1E65C41900B18908 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		50582F671E65C64B00B18908 /* ContentControlsUIProps.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentControlsUIProps.swift; sourceTree = "<group>"; };
@@ -257,6 +259,7 @@
 			isa = PBXGroup;
 			children = (
 				50582F731E65C79D00B18908 /* Utils.swift */,
+				0696270C1FD188A50098494A /* Command.swift */,
 				50582FB11E65DEF800B18908 /* Recorder.swift */,
 				50582FC31E67086000B18908 /* Defaultable.swift */,
 			);
@@ -434,6 +437,7 @@
 				DA73095D1F5FD3AD000A7364 /* EnumPrism.stencil in Sources */,
 				50582F811E65CA0F00B18908 /* AdVideoControls.swift in Sources */,
 				50582F6E1E65C64B00B18908 /* ContentControlsViewController.swift in Sources */,
+				0696270D1FD188A50098494A /* Command.swift in Sources */,
 				50582F7E1E65C96100B18908 /* SeekGestureRecognizer.swift in Sources */,
 				50582F8C1E65CBE600B18908 /* Timer.swift in Sources */,
 				50F471591F5D763500C35AEF /* SettingHeaderView.swift in Sources */,

--- a/PlayerControls/sources/AdVideoControls.swift
+++ b/PlayerControls/sources/AdVideoControls.swift
@@ -80,7 +80,7 @@ public final class AdVideoControls: UIViewController {
             case pause(Command)
         }
         
-        public struct Seeker: Codable {
+        public struct Seeker {
             public let remainingPlayTime: String
             public let currentValue: Double
             public init(remainingPlayTime: String, currentValue: Double) {

--- a/PlayerControls/sources/AdVideoControls.swift
+++ b/PlayerControls/sources/AdVideoControls.swift
@@ -25,9 +25,9 @@ public final class AdVideoControls: UIViewController {
     
     @IBOutlet public weak var containerView: UIView!
     
-    public var props: Props = Props(mainCommand: .play(.nop),
+    public var props: Props = Props(mainAction: .play(.nop),
                                     seeker: nil,
-                                    tapCommand: nil,
+                                    tapAction: nil,
                                     isLoading: true,
                                     airplayActiveViewHidden: true) {
         didSet {
@@ -48,7 +48,7 @@ public final class AdVideoControls: UIViewController {
     public override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         
-        playButton.isHidden = props.mainCommand.pause != nil
+        playButton.isHidden = props.mainAction.pause != nil
         
         pauseButton.isHidden = !playButton.isHidden
         
@@ -64,18 +64,18 @@ public final class AdVideoControls: UIViewController {
     }
     
     public struct Props {
-        public static let `default` = Props(mainCommand: .play(.nop),
+        public static let `default` = Props(mainAction: .play(.nop),
                                             seeker: nil,
-                                            tapCommand: nil,
+                                            tapAction: nil,
                                             isLoading: true,
                                             airplayActiveViewHidden: true)
-        public let mainCommand: MainCommand
+        public let mainAction: MainAction
         public let seeker: Seeker?
-        public let tapCommand: Command?
+        public let tapAction: Command?
         public let isLoading: Bool
         public let airplayActiveViewHidden: Bool
         
-        public enum MainCommand: Prism {
+        public enum MainAction: Prism {
             case play(Command)
             case pause(Command)
         }
@@ -89,14 +89,14 @@ public final class AdVideoControls: UIViewController {
             }
         }
         
-        public init(mainCommand: MainCommand,
+        public init(mainAction: MainAction,
                     seeker: Seeker?,
-                    tapCommand: Command?,
+                    tapAction: Command?,
                     isLoading: Bool,
                     airplayActiveViewHidden: Bool) {
-            self.mainCommand = mainCommand
+            self.mainAction = mainAction
             self.seeker = seeker
-            self.tapCommand = tapCommand
+            self.tapAction = tapAction
             self.isLoading = isLoading
             self.airplayActiveViewHidden = airplayActiveViewHidden
         }
@@ -111,17 +111,17 @@ public final class AdVideoControls: UIViewController {
             red: 1.0, green: 198.0 / 255.0, blue: 0, alpha: 1.0)
     }
     
-    /// Play video button Command. Replace if you need custom behavior.
+    /// Play video button command. Replace if you need custom behavior.
     @IBAction private func playButtonTouched() {
-        props.mainCommand.play?.perform()
+        props.mainAction.play?.perform()
     }
     
-    /// Pause video button Command. Replace if you need custom behavior.
+    /// Pause video button command. Replace if you need custom behavior.
     @IBAction private func pauseButtonTouched() {
-        props.mainCommand.pause?.perform()
+        props.mainAction.pause?.perform()
     }
     
-    @IBAction private func viewTouched() { props.tapCommand?.perform() }
+    @IBAction private func viewTouched() { props.tapAction?.perform() }
 }
 
 extension AdVideoControls {

--- a/PlayerControls/sources/AdVideoControls.swift
+++ b/PlayerControls/sources/AdVideoControls.swift
@@ -25,9 +25,9 @@ public final class AdVideoControls: UIViewController {
     
     @IBOutlet public weak var containerView: UIView!
     
-    public var props: Props = Props(mainAction: .play { },
+    public var props: Props = Props(mainCommand: .play(.nop),
                                     seeker: nil,
-                                    tapAction: nil,
+                                    tapCommand: nil,
                                     isLoading: true,
                                     airplayActiveViewHidden: true) {
         didSet {
@@ -48,7 +48,7 @@ public final class AdVideoControls: UIViewController {
     public override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         
-        playButton.isHidden = props.mainAction.pause != nil
+        playButton.isHidden = props.mainCommand.pause != nil
         
         pauseButton.isHidden = !playButton.isHidden
         
@@ -64,23 +64,23 @@ public final class AdVideoControls: UIViewController {
     }
     
     public struct Props {
-        public static let `default` = Props(mainAction: .play { },
+        public static let `default` = Props(mainCommand: .play(.nop),
                                             seeker: nil,
-                                            tapAction: nil,
+                                            tapCommand: nil,
                                             isLoading: true,
                                             airplayActiveViewHidden: true)
-        public let mainAction: MainAction
+        public let mainCommand: MainCommand
         public let seeker: Seeker?
-        public let tapAction: Action<Void>?
+        public let tapCommand: Command?
         public let isLoading: Bool
         public let airplayActiveViewHidden: Bool
         
-        public enum MainAction: Prism {
-            case play(Action<Void>)
-            case pause(Action<Void>)
+        public enum MainCommand: Prism {
+            case play(Command)
+            case pause(Command)
         }
         
-        public struct Seeker {
+        public struct Seeker: Codable {
             public let remainingPlayTime: String
             public let currentValue: Double
             public init(remainingPlayTime: String, currentValue: Double) {
@@ -89,14 +89,14 @@ public final class AdVideoControls: UIViewController {
             }
         }
         
-        public init(mainAction: MainAction,
+        public init(mainCommand: MainCommand,
                     seeker: Seeker?,
-                    tapAction: Action<Void>?,
+                    tapCommand: Command?,
                     isLoading: Bool,
                     airplayActiveViewHidden: Bool) {
-            self.mainAction = mainAction
+            self.mainCommand = mainCommand
             self.seeker = seeker
-            self.tapAction = tapAction
+            self.tapCommand = tapCommand
             self.isLoading = isLoading
             self.airplayActiveViewHidden = airplayActiveViewHidden
         }
@@ -111,17 +111,17 @@ public final class AdVideoControls: UIViewController {
             red: 1.0, green: 198.0 / 255.0, blue: 0, alpha: 1.0)
     }
     
-    /// Play video button action. Replace if you need custom behavior.
+    /// Play video button Command. Replace if you need custom behavior.
     @IBAction private func playButtonTouched() {
-        props.mainAction.play?()
+        props.mainCommand.play?.perform()
     }
     
-    /// Pause video button action. Replace if you need custom behavior.
+    /// Pause video button Command. Replace if you need custom behavior.
     @IBAction private func pauseButtonTouched() {
-        props.mainAction.pause?()
+        props.mainCommand.pause?.perform()
     }
     
-    @IBAction private func viewTouched() { props.tapAction?() }
+    @IBAction private func viewTouched() { props.tapCommand?.perform() }
 }
 
 extension AdVideoControls {

--- a/PlayerControls/sources/Command.swift
+++ b/PlayerControls/sources/Command.swift
@@ -1,0 +1,32 @@
+//  Copyright © 2017 One by AOL : Publishers. All rights reserved.
+
+public typealias Command = CommandWith<Void>
+
+public struct CommandWith<T> {
+    private var action: (T) -> Void
+    
+    public static var nop: CommandWith { return CommandWith { _ in } }
+    
+    public init(action: @escaping (T) -> Void) {
+        self.action = action
+    }
+    public func perform(with value: T) {
+        self.action(value)
+    }
+}
+
+extension CommandWith where T == Void {
+    public func perform() {
+        self.perform(with: ())
+    }
+}
+
+extension CommandWith {
+    func bind(to value: T) -> Command {
+        return Command { self.perform(with: value) }
+    }
+    
+    func map<U>(block: @escaping (U) -> T) -> CommandWith<U> {
+        return CommandWith<U> { self.perform(with: block($0)) }
+    }
+}

--- a/PlayerControls/sources/ContentControlsUIProps.swift
+++ b/PlayerControls/sources/ContentControlsUIProps.swift
@@ -8,20 +8,20 @@ extension DefaultControlsViewController {
         var controlsViewHidden: Bool
         
         var playButtonHidden: Bool
-        var playButtonCommand: Command
+        var playButtonAction: Command
         
         var pauseButtonHidden: Bool
-        var pauseButtonCommand: Command
+        var pauseButtonAction: Command
         
         var replayButtonHidden: Bool
-        var replayButtonCommand: Command
+        var replayButtonAction: Command
         
         var nextButtonHidden: Bool
-        var nextButtonCommand: Command
+        var nextButtonAction: Command
         var nextButtonEnabled: Bool
         
         var prevButtonHidden: Bool
-        var prevButtonCommand: Command
+        var prevButtonAction: Command
         var prevButtonEnabled: Bool
         
         var seekerViewHidden: Bool
@@ -29,10 +29,10 @@ extension DefaultControlsViewController {
         var seekerViewCurrentTime: UInt
         var seekerViewProgress: CGFloat
         var seekerViewBuffered: CGFloat
-        var startSeekCommand: CommandWith<Double>
-        var updateSeekCommand: CommandWith<Double>
-        var stopSeekCommand: CommandWith<Double>
-        var seekToSecondsCommand: CommandWith<UInt>
+        var startSeekAction: CommandWith<Double>
+        var updateSeekAction: CommandWith<Double>
+        var stopSeekAction: CommandWith<Double>
+        var seekToSecondsAction: CommandWith<UInt>
         var seekBackButtonHidden: Bool
         var seekForwardButtonHidden: Bool
         var seekbarPositionedAtBottom: Bool
@@ -62,15 +62,15 @@ extension DefaultControlsViewController {
         var errorLabelHidden: Bool
         var errorLabelText: String
         var retryButtonHidden: Bool
-        var retryButtonCommand: Command
+        var retryButtonAction: Command
         
         var pipButtonHidden: Bool
         var pipButtonEnabled: Bool
-        var pipButtonCommand: Command
+        var pipButtonAction: Command
         
         var settingsButtonHidden: Bool
         var settingsButtonEnabled: Bool
-        var settingsButtonCommand: Command
+        var settingsButtonAction: Command
         
         var airplayActiveLabelHidden: Bool
         var airplayButtonHidden: Bool
@@ -91,25 +91,25 @@ extension DefaultControlsViewController {
             
             loading = props.player?.item.playable?.loading ?? false
             
-            playButtonHidden = props.player?.item.playable?.playbackCommand.play == nil
+            playButtonHidden = props.player?.item.playable?.playbackAction.play == nil
             
-            playButtonCommand = props.player?.item.playable?.playbackCommand.play ?? .nop
+            playButtonAction = props.player?.item.playable?.playbackAction.play ?? .nop
             
-            pauseButtonHidden = props.player?.item.playable?.playbackCommand.pause == nil
+            pauseButtonHidden = props.player?.item.playable?.playbackAction.pause == nil
             
-            pauseButtonCommand = props.player?.item.playable?.playbackCommand.pause ?? .nop
+            pauseButtonAction = props.player?.item.playable?.playbackAction.pause ?? .nop
             
-            replayButtonHidden = props.player?.item.playable?.playbackCommand.replay == nil
+            replayButtonHidden = props.player?.item.playable?.playbackAction.replay == nil
             
-            replayButtonCommand = props.player?.item.playable?.playbackCommand.replay ?? .nop
+            replayButtonAction = props.player?.item.playable?.playbackAction.replay ?? .nop
             
             nextButtonEnabled = props.player?.playlist?.next != nil
             
-            nextButtonCommand = props.player?.playlist?.next ?? .nop
+            nextButtonAction = props.player?.playlist?.next ?? .nop
             
             prevButtonEnabled = props.player?.playlist?.prev != nil
             
-            prevButtonCommand = props.player?.playlist?.prev ?? .nop
+            prevButtonAction = props.player?.playlist?.prev ?? .nop
             
             let nextButtonDisabled = !nextButtonEnabled
             let prevButtonDisabled = !prevButtonEnabled
@@ -131,13 +131,13 @@ extension DefaultControlsViewController {
             
             seekForwardButtonHidden = props.player?.item.playable?.seekbar?.seeker.seekTo == nil
             
-            seekToSecondsCommand = props.player?.item.playable?.seekbar?.seeker.seekTo ?? .nop
+            seekToSecondsAction = props.player?.item.playable?.seekbar?.seeker.seekTo ?? .nop
             
-            startSeekCommand = props.player?.item.playable?.seekbar?.seeker.state.start ?? .nop
+            startSeekAction = props.player?.item.playable?.seekbar?.seeker.state.start ?? .nop
             
-            updateSeekCommand = props.player?.item.playable?.seekbar?.seeker.state.update ?? .nop
+            updateSeekAction = props.player?.item.playable?.seekbar?.seeker.state.update ?? .nop
             
-            stopSeekCommand = props.player?.item.playable?.seekbar?.seeker.state.stop ?? .nop
+            stopSeekAction = props.player?.item.playable?.seekbar?.seeker.state.stop ?? .nop
             
             seekerViewCurrentTimeText = {
                 guard let seekbar = props.player?.item.playable?.seekbar else { return "" }
@@ -213,19 +213,19 @@ extension DefaultControlsViewController {
             
             retryButtonHidden = props.player?.item.playable?.error == nil
             
-            retryButtonCommand = props.player?.item.playable?.error?.retryCommand ?? .nop
+            retryButtonAction = props.player?.item.playable?.error?.retryAction ?? .nop
             
             pipButtonHidden = props.player?.item.playable?.pictureInPictureControl.isUnsupported ?? true
             
             pipButtonEnabled = props.player?.item.playable?.pictureInPictureControl.possible != nil
             
-            pipButtonCommand = props.player?.item.playable?.pictureInPictureControl.possible ?? .nop
+            pipButtonAction = props.player?.item.playable?.pictureInPictureControl.possible ?? .nop
             
             settingsButtonHidden = props.player?.item.playable?.settings.isHidden ?? true
             
             settingsButtonEnabled = props.player?.item.playable?.settings.enabled != nil
             
-            settingsButtonCommand = props.player?.item.playable?.settings.enabled ?? .nop
+            settingsButtonAction = props.player?.item.playable?.settings.enabled ?? .nop
             
             airplayActiveLabelHidden = !(props.player?.item.playable?.airplay.isActive ?? false)
             airplayButtonHidden = props.player?.item.playable?.airplay.isHidden ?? true

--- a/PlayerControls/sources/ContentControlsUIProps.swift
+++ b/PlayerControls/sources/ContentControlsUIProps.swift
@@ -91,17 +91,17 @@ extension DefaultControlsViewController {
             
             loading = props.player?.item.playable?.loading ?? false
             
-            playButtonHidden = props.player?.item.playable?.playbackAction.play == nil
+            playButtonHidden = props.player?.item.playable?.playbackCommand.play == nil
             
-            playButtonCommand = props.player?.item.playable?.playbackAction.play ?? .nop
+            playButtonCommand = props.player?.item.playable?.playbackCommand.play ?? .nop
             
-            pauseButtonHidden = props.player?.item.playable?.playbackAction.pause == nil
+            pauseButtonHidden = props.player?.item.playable?.playbackCommand.pause == nil
             
-            pauseButtonCommand = props.player?.item.playable?.playbackAction.pause ?? .nop
+            pauseButtonCommand = props.player?.item.playable?.playbackCommand.pause ?? .nop
             
-            replayButtonHidden = props.player?.item.playable?.playbackAction.replay == nil
+            replayButtonHidden = props.player?.item.playable?.playbackCommand.replay == nil
             
-            replayButtonCommand = props.player?.item.playable?.playbackAction.replay ?? .nop
+            replayButtonCommand = props.player?.item.playable?.playbackCommand.replay ?? .nop
             
             nextButtonEnabled = props.player?.playlist?.next != nil
             

--- a/PlayerControls/sources/ContentControlsUIProps.swift
+++ b/PlayerControls/sources/ContentControlsUIProps.swift
@@ -8,20 +8,20 @@ extension DefaultControlsViewController {
         var controlsViewHidden: Bool
         
         var playButtonHidden: Bool
-        var playButtonAction: Action<Void>
+        var playButtonCommand: Command
         
         var pauseButtonHidden: Bool
-        var pauseButtonAction: Action<Void>
+        var pauseButtonCommand: Command
         
         var replayButtonHidden: Bool
-        var replayButtonAction: Action<Void>
+        var replayButtonCommand: Command
         
         var nextButtonHidden: Bool
-        var nextButtonAction: Action<Void>
+        var nextButtonCommand: Command
         var nextButtonEnabled: Bool
         
         var prevButtonHidden: Bool
-        var prevButtonAction: Action<Void>
+        var prevButtonCommand: Command
         var prevButtonEnabled: Bool
         
         var seekerViewHidden: Bool
@@ -29,10 +29,10 @@ extension DefaultControlsViewController {
         var seekerViewCurrentTime: UInt
         var seekerViewProgress: CGFloat
         var seekerViewBuffered: CGFloat
-        var startSeekAction: Action<Double>
-        var updateSeekAction: Action<Double>
-        var stopSeekAction: Action<Double>
-        var seekToSecondsAction: Action<UInt>
+        var startSeekCommand: CommandWith<Double>
+        var updateSeekCommand: CommandWith<Double>
+        var stopSeekCommand: CommandWith<Double>
+        var seekToSecondsCommand: CommandWith<UInt>
         var seekBackButtonHidden: Bool
         var seekForwardButtonHidden: Bool
         var seekbarPositionedAtBottom: Bool
@@ -42,8 +42,8 @@ extension DefaultControlsViewController {
         var compasBodyViewHidden: Bool
         var compasDirectionViewHidden: Bool
         var compasDirectionViewTransform: CGAffineTransform
-        var updateCameraAngles: Action<CGPoint>
-        var resetCameraAngles: Action<Void>
+        var updateCameraAngles: CommandWith<CGPoint>
+        var resetCameraAngles: Command
         var cameraPanGestureIsEnabled: Bool
         var compassViewBelowLive: Bool
         
@@ -62,15 +62,15 @@ extension DefaultControlsViewController {
         var errorLabelHidden: Bool
         var errorLabelText: String
         var retryButtonHidden: Bool
-        var retryButtonAction: Action<Void>
+        var retryButtonCommand: Command
         
         var pipButtonHidden: Bool
         var pipButtonEnabled: Bool
-        var pipButtonAction: Action<Void>
+        var pipButtonCommand: Command
         
         var settingsButtonHidden: Bool
         var settingsButtonEnabled: Bool
-        var settingsButtonAction: Action<Void>
+        var settingsButtonCommand: Command
         
         var airplayActiveLabelHidden: Bool
         var airplayButtonHidden: Bool
@@ -93,23 +93,23 @@ extension DefaultControlsViewController {
             
             playButtonHidden = props.player?.item.playable?.playbackAction.play == nil
             
-            playButtonAction = props.player?.item.playable?.playbackAction.play ?? nop
+            playButtonCommand = props.player?.item.playable?.playbackAction.play ?? .nop
             
             pauseButtonHidden = props.player?.item.playable?.playbackAction.pause == nil
             
-            pauseButtonAction = props.player?.item.playable?.playbackAction.pause ?? nop
+            pauseButtonCommand = props.player?.item.playable?.playbackAction.pause ?? .nop
             
             replayButtonHidden = props.player?.item.playable?.playbackAction.replay == nil
             
-            replayButtonAction = props.player?.item.playable?.playbackAction.replay ?? nop
+            replayButtonCommand = props.player?.item.playable?.playbackAction.replay ?? .nop
             
             nextButtonEnabled = props.player?.playlist?.next != nil
             
-            nextButtonAction = props.player?.playlist?.next ?? nop
+            nextButtonCommand = props.player?.playlist?.next ?? .nop
             
             prevButtonEnabled = props.player?.playlist?.prev != nil
             
-            prevButtonAction = props.player?.playlist?.prev ?? nop
+            prevButtonCommand = props.player?.playlist?.prev ?? .nop
             
             let nextButtonDisabled = !nextButtonEnabled
             let prevButtonDisabled = !prevButtonEnabled
@@ -131,13 +131,13 @@ extension DefaultControlsViewController {
             
             seekForwardButtonHidden = props.player?.item.playable?.seekbar?.seeker.seekTo == nil
             
-            seekToSecondsAction = props.player?.item.playable?.seekbar?.seeker.seekTo ?? nop
+            seekToSecondsCommand = props.player?.item.playable?.seekbar?.seeker.seekTo ?? .nop
             
-            startSeekAction = props.player?.item.playable?.seekbar?.seeker.state.start ?? nop
+            startSeekCommand = props.player?.item.playable?.seekbar?.seeker.state.start ?? .nop
             
-            updateSeekAction = props.player?.item.playable?.seekbar?.seeker.state.update ?? nop
+            updateSeekCommand = props.player?.item.playable?.seekbar?.seeker.state.update ?? .nop
             
-            stopSeekAction = props.player?.item.playable?.seekbar?.seeker.state.stop ?? nop
+            stopSeekCommand = props.player?.item.playable?.seekbar?.seeker.state.stop ?? .nop
             
             seekerViewCurrentTimeText = {
                 guard let seekbar = props.player?.item.playable?.seekbar else { return "" }
@@ -171,19 +171,18 @@ extension DefaultControlsViewController {
             }()
             
             updateCameraAngles = {
-                guard let camera = props.player?.item.playable?.camera else { return nop }
-                return { translation in
+                guard let camera = props.player?.item.playable?.camera else { return .nop }
+                return camera.moveTo.map { translation in
                     var angles = camera.angles
                     angles.horizontal += Float(translation.x) * 0.01
                     angles.vertical += Float(translation.y) * 0.01
-                    
-                    camera.moveTo(angles)
+                    return angles
                 }
             }()
             
             resetCameraAngles = {
-                guard let camera = props.player?.item.playable?.camera else { return nop }
-                return { camera.moveTo(.init()) }
+                guard let camera = props.player?.item.playable?.camera else { return .nop }
+                return camera.moveTo.bind(to: .init())
             }()
             
             cameraPanGestureIsEnabled = props.player?.item.playable?.camera != nil
@@ -214,26 +213,26 @@ extension DefaultControlsViewController {
             
             retryButtonHidden = props.player?.item.playable?.error == nil
             
-            retryButtonAction = props.player?.item.playable?.error?.retryAction ?? nop
+            retryButtonCommand = props.player?.item.playable?.error?.retryCommand ?? .nop
             
             pipButtonHidden = props.player?.item.playable?.pictureInPictureControl.isUnsupported ?? true
             
             pipButtonEnabled = props.player?.item.playable?.pictureInPictureControl.possible != nil
             
-            pipButtonAction = props.player?.item.playable?.pictureInPictureControl.possible ?? nop
+            pipButtonCommand = props.player?.item.playable?.pictureInPictureControl.possible ?? .nop
             
             settingsButtonHidden = props.player?.item.playable?.settings.isHidden ?? true
             
             settingsButtonEnabled = props.player?.item.playable?.settings.enabled != nil
             
-            settingsButtonAction = props.player?.item.playable?.settings.enabled ?? nop
+            settingsButtonCommand = props.player?.item.playable?.settings.enabled ?? .nop
             
             airplayActiveLabelHidden = !(props.player?.item.playable?.airplay.isActive ?? false)
             airplayButtonHidden = props.player?.item.playable?.airplay.isHidden ?? true
             
             liveIndicationViewIsHidden = props.player?.item.playable?.live.isHidden ?? true
             
-            liveDotColor = props.player?.item.playable?.live.dotColor
+            liveDotColor = props.player?.item.playable?.live.dotColor ?? nil
             
             compassViewBelowLive = {
                 guard

--- a/PlayerControls/sources/ContentControlsViewController.swift
+++ b/PlayerControls/sources/ContentControlsViewController.swift
@@ -48,7 +48,7 @@ extension ContentControlsViewController.Props.Player.Item {
         public var title = ""
         public var loading = false
         
-        public var playbackCommand: Playback = .none
+        public var playbackAction: Playback = .none
             public enum Playback: Prism {
             case none
             case play(Command)
@@ -121,7 +121,7 @@ extension ContentControlsViewController.Props.Player.Item {
         public var error: Error?
         public struct Error {
             public var message = ""
-            public var retryCommand: Command?
+            public var retryAction: Command?
             public init() { }
         }
         

--- a/PlayerControls/sources/ContentControlsViewController.swift
+++ b/PlayerControls/sources/ContentControlsViewController.swift
@@ -19,7 +19,7 @@ open class ContentControlsViewController: UIViewController {
     
     public enum Props: Prism {
         case noPlayer
-
+        
         case player(Player)
         
         case pictureInPicture
@@ -27,12 +27,13 @@ open class ContentControlsViewController: UIViewController {
         public struct Player {
             public var playlist: Playlist?
             public struct Playlist {
-                public var next: Action<Void>?
-                public var prev: Action<Void>?
+                public var next: Command?
+                public var prev: Command?
                 public init() { }
             }
-
+            
             public var item = Item.nonplayable("")
+            
             public enum Item: Prism {
                 case playable(Controls)
                 case nonplayable(String)
@@ -51,9 +52,9 @@ extension ContentControlsViewController.Props.Player.Item {
         public var playbackAction: Playback = .none
         public enum Playback: Prism {
             case none
-            case play(Action<Void>)
-            case pause(Action<Void>)
-            case replay(Action<Void>)
+            case play(CommandWith<Void>)
+            case pause(CommandWith<Void>)
+            case replay(CommandWith<Void>)
         }
         
         public var live = Live()
@@ -75,13 +76,13 @@ extension ContentControlsViewController.Props.Player.Item {
             public var seeker = Seeker()
             
             public struct Seeker {
-                public var seekTo: Action<Seconds>?
+                public var seekTo: CommandWith<Seconds>?
                 
                 public var state = State()
                 public struct State {
-                    public var start: Action<Progress> = nop
-                    public var update: Action<Progress> = nop
-                    public var stop: Action<Progress> = nop
+                    public var start: CommandWith<Progress> = .nop
+                    public var update: CommandWith<Progress> = .nop
+                    public var stop: CommandWith<Progress> = .nop
                     public init() { }
                 }
                 public init() { }
@@ -104,7 +105,7 @@ extension ContentControlsViewController.Props.Player.Item {
             }
             
             public var angles = Angles()
-            public var moveTo: Action<Angles> = nop
+            public var moveTo: CommandWith<Angles> = .nop
             public init() { }
         }
         
@@ -115,12 +116,13 @@ extension ContentControlsViewController.Props.Player.Item {
             case image(UIImage)
         }
         
+        
         public var sideBarViewHidden = true
         
         public var error: Error?
         public struct Error {
             public var message = ""
-            public var retryAction: Action<Void>?
+            public var retryCommand: CommandWith<Void>?
             public init() { }
         }
         
@@ -128,7 +130,7 @@ extension ContentControlsViewController.Props.Player.Item {
         public enum PictureInPictureControl: Prism {
             case unsupported
             case impossible
-            case possible(Action<Void>)
+            case possible(Command)
         }
         
         public enum Subtitles: Prism {
@@ -150,7 +152,7 @@ extension ContentControlsViewController.Props.Player.Item {
             public struct Option {
                 public var name = ""
                 public var selected = false
-                public var select: Action<Void> = nop
+                public var select: Command? = Command.nop
                 public init() { }
             }
             
@@ -163,7 +165,7 @@ extension ContentControlsViewController.Props.Player.Item {
         public enum Settings: Prism {
             case hidden
             case disabled
-            case enabled(Action<Void>)
+            case enabled(Command)
         }
         public var settings: Settings = .disabled
         

--- a/PlayerControls/sources/ContentControlsViewController.swift
+++ b/PlayerControls/sources/ContentControlsViewController.swift
@@ -4,7 +4,6 @@ import Foundation
 
 ///Generate prism for confirmed enum 
 public protocol Prism {}
-
 /// Base class for implementing custom content
 /// video controls.
 open class ContentControlsViewController: UIViewController {
@@ -52,9 +51,9 @@ extension ContentControlsViewController.Props.Player.Item {
         public var playbackAction: Playback = .none
         public enum Playback: Prism {
             case none
-            case play(CommandWith<Void>)
-            case pause(CommandWith<Void>)
-            case replay(CommandWith<Void>)
+            case play(Command)
+            case pause(Command)
+            case replay(Command)
         }
         
         public var live = Live()
@@ -122,7 +121,7 @@ extension ContentControlsViewController.Props.Player.Item {
         public var error: Error?
         public struct Error {
             public var message = ""
-            public var retryCommand: CommandWith<Void>?
+            public var retryCommand: Command?
             public init() { }
         }
         
@@ -152,7 +151,7 @@ extension ContentControlsViewController.Props.Player.Item {
             public struct Option {
                 public var name = ""
                 public var selected = false
-                public var select: Command? = Command.nop
+                public var select: Command = .nop
                 public init() { }
             }
             

--- a/PlayerControls/sources/ContentControlsViewController.swift
+++ b/PlayerControls/sources/ContentControlsViewController.swift
@@ -48,8 +48,8 @@ extension ContentControlsViewController.Props.Player.Item {
         public var title = ""
         public var loading = false
         
-        public var playbackAction: Playback = .none
-        public enum Playback: Prism {
+        public var playbackCommand: Playback = .none
+            public enum Playback: Prism {
             case none
             case play(Command)
             case pause(Command)

--- a/PlayerControls/sources/ControlsVisibilityController.swift
+++ b/PlayerControls/sources/ControlsVisibilityController.swift
@@ -31,14 +31,14 @@ public class ControlsPresentationController {
         let internalTimer = Timer(
             start: Command {
                 timer?.cancel()
-                timer = PlayerControls.Timer(duration: 3, fire: fire)}
+                timer = PlayerControls.Timer(duration: 3, fire: CommandWith { fire?.perform() })}
         ,
             stop:  Command {
                 timer?.cancel()
         })
         
         self.init(controls: controls, timer: internalTimer)
-        fire = .init { [weak self] in self?.timerFired() }
+        fire = CommandWith { [weak self] in self?.timerFired() }
         
         
         // At the end. self -> Timer -> OneMobileSDK.Timer -> [weak self]
@@ -55,22 +55,22 @@ public class ControlsPresentationController {
         case tap, timerFired, play, pause, resetTimer
     }
     
-    private var behavior: CommandWith<Message> = CommandWith(action: { fatalError("Unhandled message: \($0)") })
+    private var behavior: CommandWith<Message> = CommandWith { fatalError("Unhandled message: \($0)") }
     
     private func start() {
         controls.show.perform()
-        behavior = CommandWith(action: { [weak self] in self?.visiblePaused(by: $0) })
+        behavior = CommandWith { [weak self] in self?.visiblePaused(by: $0) }
     }
     
     private func visiblePaused(by message: Message) {
         switch message {
         case .tap:
             controls.hide.perform()
-            behavior = CommandWith(action: { [weak self] in self?.hiddenPaused(by: $0) })
+            behavior = CommandWith { [weak self] in self?.hiddenPaused(by: $0) }
             
         case .play:
             timer.start.perform()
-            behavior = CommandWith(action: { [weak self] in self?.visiblePlaying(by: $0) })
+            behavior = CommandWith { [weak self] in self?.visiblePlaying(by: $0) }
             
         case .resetTimer: break
             
@@ -81,10 +81,10 @@ public class ControlsPresentationController {
         switch message {
         case .tap:
             controls.show.perform()
-            behavior = CommandWith(action: { [weak self] in self?.visiblePaused(by: $0) })
+            behavior = CommandWith { [weak self] in self?.visiblePaused(by: $0) }
             
         case .play:
-            behavior = CommandWith(action: { [weak self] in self?.hiddenPlaying(by: $0) })
+            behavior = CommandWith { [weak self] in self?.hiddenPlaying(by: $0) }
             
         default: fatalError("Unhandled message: \(message)") }
     }
@@ -94,15 +94,15 @@ public class ControlsPresentationController {
         case .tap:
             timer.stop.perform()
             controls.hide.perform()
-            behavior = CommandWith(action: { [weak self] in self?.hiddenPlaying(by: $0) })
+            behavior = CommandWith { [weak self] in self?.hiddenPlaying(by: $0) }
             
         case .pause:
             timer.stop.perform()
-            behavior = CommandWith(action: { [weak self] in self?.visiblePaused(by: $0) })
+            behavior = CommandWith { [weak self] in self?.visiblePaused(by: $0) }
             
         case .timerFired:
             controls.hide.perform()
-            behavior = CommandWith(action: { [weak self] in self?.hiddenPlaying(by: $0) })
+            behavior = CommandWith { [weak self] in self?.hiddenPlaying(by: $0) }
             
         case .resetTimer:
             timer.stop.perform()
@@ -116,11 +116,11 @@ public class ControlsPresentationController {
         case .tap:
             controls.show.perform()
             timer.start.perform()
-            behavior = CommandWith(action: { [weak self] in self?.visiblePlaying(by: $0) })
+            behavior = CommandWith { [weak self] in self?.visiblePlaying(by: $0) }
             
         case .pause:
             controls.show.perform()
-            behavior = CommandWith(action: { [weak self] in self?.visiblePaused(by: $0) })
+            behavior = CommandWith { [weak self] in self?.visiblePaused(by: $0) }
             
         case .resetTimer: break
             

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -236,7 +236,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         func isVideoPlaying(for props: ContentControlsViewController.Props) -> Bool {
             guard case .player(let player) = props else { return false }
             guard case .playable(let contentProps) = player.item else { return false }
-            guard case .pause = contentProps.playbackAction else { return false }
+            guard case .pause = contentProps.playbackCommand else { return false }
             return true
         }
         
@@ -268,10 +268,10 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         
         let visibilityController = ControlsPresentationController(controls: controls)
         
-        onUserInteraction = CommandWith(action: visibilityController.resetTimer)
-        onTapEvent = CommandWith(action: visibilityController.tap)
-        onPlayEvent = CommandWith(action: visibilityController.play)
-        onPauseEvent = CommandWith(action: visibilityController.pause)
+        onUserInteraction = CommandWith { visibilityController.resetTimer() }
+        onTapEvent = CommandWith { visibilityController.tap() }
+        onPlayEvent = CommandWith { visibilityController.play() }
+        onPauseEvent = CommandWith { visibilityController.pause() }
     }
  
     @IBAction private func playButtonTouched() {

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -3,7 +3,7 @@ import MediaPlayer
 
 /// This class contains all controls that
 /// are defined for Player View Controller default UI.
-/// You can replace actions with your own
+/// You can replace commands with your own
 /// and customise controls according to your needs.
 public final class DefaultControlsViewController: ContentControlsViewController {
     public init() {
@@ -69,9 +69,9 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             sideBarView.props = sidebarProps.map { [weak self] in
                 var props = $0
                 let handler = props.handler
-                props.handler = {
-                    self?.onUserInteraction?()
-                    handler()
+                props.handler = .init {
+                    self?.onUserInteraction?.perform()
+                    handler.perform()
                 }
                 return props
             }
@@ -80,13 +80,13 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     
     public override func viewDidLoad() {
         super.viewDidLoad()
-        seekerView.callbacks.onDragStarted = { [unowned self] value in
+        seekerView.callbacks.onDragStarted = .init { [unowned self] value in
             self.startSeek(from: value)
         }
-        seekerView.callbacks.onDragChanged = { [unowned self] value in
+        seekerView.callbacks.onDragChanged = .init { [unowned self] value in
             self.updateSeek(to: value)
         }
-        seekerView.callbacks.onDragFinished = { [unowned self] value in
+        seekerView.callbacks.onDragFinished = .init { [unowned self] value in
             self.stopSeek(at: value)
         }
     }
@@ -224,10 +224,10 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         }
     }
     
-    public var onPlayEvent: Action<Void>?
-    public var onPauseEvent: Action<Void>?
-    public var onTapEvent: Action<Void>?
-    public var onUserInteraction: Action<Void>?
+    public var onPlayEvent: Command?
+    public var onPauseEvent: Command?
+    public var onTapEvent: Command?
+    public var onUserInteraction: Command?
     
     func updateVisibilityController( //swiftlint:disable:this cyclomatic_complexity
         from old: ContentControlsViewController.Props,
@@ -243,8 +243,8 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         switch (isVideoPlaying(for: old), isVideoPlaying(for: new)) {
         case (true, true): break
         case (false, false): break
-        case (false, true): onPlayEvent?()
-        case (true, false): onPauseEvent?()
+        case (false, true): onPlayEvent?.perform()
+        case (true, false): onPauseEvent?.perform()
         }
     }
     
@@ -263,95 +263,95 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     func setupVisibilityController() {
         weak var weakSelf = self
         let controls = ControlsPresentationController.Controls(
-            show: { weakSelf?.showControls() },
-            hide: { weakSelf?.hideControls() })
+            show: CommandWith { weakSelf?.showControls() },
+            hide: CommandWith { weakSelf?.hideControls() })
         
         let visibilityController = ControlsPresentationController(controls: controls)
         
-        onUserInteraction = visibilityController.resetTimer
-        onTapEvent = visibilityController.tap
-        onPlayEvent = visibilityController.play
-        onPauseEvent = visibilityController.pause
+        onUserInteraction = CommandWith(action: visibilityController.resetTimer)
+        onTapEvent = CommandWith(action: visibilityController.tap)
+        onPlayEvent = CommandWith(action: visibilityController.play)
+        onPauseEvent = CommandWith(action: visibilityController.pause)
     }
-    
+ 
     @IBAction private func playButtonTouched() {
-        uiProps.playButtonAction()
-        onUserInteraction?()
+        uiProps.playButtonCommand.perform()
+        onUserInteraction?.perform()
     }
     
     @IBAction private func pauseButtonTouched() {
-        uiProps.pauseButtonAction()
-		onUserInteraction?()
+        uiProps.pauseButtonCommand.perform()
+		onUserInteraction?.perform()
     }
     
     @IBAction private func replayButtonTouched() {
-        uiProps.replayButtonAction()
-        onUserInteraction?()
+        uiProps.replayButtonCommand.perform()
+        onUserInteraction?.perform()
     }
     
     @IBAction private func nextButtonTouched() {
-        uiProps.nextButtonAction()
-        onUserInteraction?()
+        uiProps.nextButtonCommand.perform()
+        onUserInteraction?.perform()
     }
     
     @IBAction private func prevButtonTouched() {
-        uiProps.prevButtonAction()
-        onUserInteraction?()
+        uiProps.prevButtonCommand.perform()
+        onUserInteraction?.perform()
     }
     
     private func startSeek(from progress: CGFloat) {
-        uiProps.startSeekAction(.init(progress))
-		onUserInteraction?()
+        uiProps.startSeekCommand.perform(with: .init(progress))
+		onUserInteraction?.perform()
     }
     
     private func updateSeek(to progress: CGFloat) {
-        uiProps.updateSeekAction(.init(progress))
-		onUserInteraction?()
+        uiProps.updateSeekCommand.perform(with: .init(progress))
+		onUserInteraction?.perform()
     }
     
     private func stopSeek(at progress: CGFloat) {
-        uiProps.stopSeekAction(.init(progress))
-		onUserInteraction?()
+        uiProps.stopSeekCommand.perform(with: .init(progress))
+		onUserInteraction?.perform()
     }
     
     @IBAction private func seekForwardButtonTouched() {
-        uiProps.seekToSecondsAction(uiProps.seekerViewCurrentTime.advanced(by: 10))
-        onUserInteraction?()
+        uiProps.seekToSecondsCommand.perform(with: uiProps.seekerViewCurrentTime.advanced(by: 10))
+        onUserInteraction?.perform()
     }
     
     @IBAction private func seekBackButtonTouched() {
         let value = uiProps.seekerViewCurrentTime
-        uiProps.seekToSecondsAction(value - min(value, 10))
-        onUserInteraction?()
+        uiProps.seekToSecondsCommand.perform(with: value - min(value, 10))
+        onUserInteraction?.perform()
     }
     
     @IBAction private func onEmptySpaceTap() {
-        onTapEvent?()
+        onTapEvent?.perform()
     }
     
     @IBAction private func onCameraPan(with recognizer: UIPanGestureRecognizer) {
         let translation = recognizer.translation(in: recognizer.view)
         recognizer.setTranslation(CGPoint.zero, in: recognizer.view)
         
-        uiProps.updateCameraAngles(translation)
+        uiProps.updateCameraAngles.perform(with: translation)
     }
     
     @IBAction private func resetCamera() {
-        uiProps.resetCameraAngles()
-        onUserInteraction?()
+        uiProps.resetCameraAngles.perform()
+        onUserInteraction?.perform()
     }
     
     @IBAction private func retry() {
-        uiProps.retryButtonAction()
-        onUserInteraction?()
+        uiProps.retryButtonCommand.perform()
+        onUserInteraction?.perform()
     }
     
     @IBAction private func pipButtonTouched() {
-        uiProps.pipButtonAction()
-        onUserInteraction?()
+        uiProps.pipButtonCommand.perform()
+        onUserInteraction?.perform()
     }
     
     @IBAction private func settingsButtonTouched() {
-        uiProps.settingsButtonAction()
+        uiProps.settingsButtonCommand.perform()
     }
 }

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -236,7 +236,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         func isVideoPlaying(for props: ContentControlsViewController.Props) -> Bool {
             guard case .player(let player) = props else { return false }
             guard case .playable(let contentProps) = player.item else { return false }
-            guard case .pause = contentProps.playbackCommand else { return false }
+            guard case .pause = contentProps.playbackAction else { return false }
             return true
         }
         
@@ -275,53 +275,53 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     }
  
     @IBAction private func playButtonTouched() {
-        uiProps.playButtonCommand.perform()
+        uiProps.playButtonAction.perform()
         onUserInteraction?.perform()
     }
     
     @IBAction private func pauseButtonTouched() {
-        uiProps.pauseButtonCommand.perform()
+        uiProps.pauseButtonAction.perform()
 		onUserInteraction?.perform()
     }
     
     @IBAction private func replayButtonTouched() {
-        uiProps.replayButtonCommand.perform()
+        uiProps.replayButtonAction.perform()
         onUserInteraction?.perform()
     }
     
     @IBAction private func nextButtonTouched() {
-        uiProps.nextButtonCommand.perform()
+        uiProps.nextButtonAction.perform()
         onUserInteraction?.perform()
     }
     
     @IBAction private func prevButtonTouched() {
-        uiProps.prevButtonCommand.perform()
+        uiProps.prevButtonAction.perform()
         onUserInteraction?.perform()
     }
     
     private func startSeek(from progress: CGFloat) {
-        uiProps.startSeekCommand.perform(with: .init(progress))
+        uiProps.startSeekAction.perform(with: .init(progress))
 		onUserInteraction?.perform()
     }
     
     private func updateSeek(to progress: CGFloat) {
-        uiProps.updateSeekCommand.perform(with: .init(progress))
+        uiProps.updateSeekAction.perform(with: .init(progress))
 		onUserInteraction?.perform()
     }
     
     private func stopSeek(at progress: CGFloat) {
-        uiProps.stopSeekCommand.perform(with: .init(progress))
+        uiProps.stopSeekAction.perform(with: .init(progress))
 		onUserInteraction?.perform()
     }
     
     @IBAction private func seekForwardButtonTouched() {
-        uiProps.seekToSecondsCommand.perform(with: uiProps.seekerViewCurrentTime.advanced(by: 10))
+        uiProps.seekToSecondsAction.perform(with: uiProps.seekerViewCurrentTime.advanced(by: 10))
         onUserInteraction?.perform()
     }
     
     @IBAction private func seekBackButtonTouched() {
         let value = uiProps.seekerViewCurrentTime
-        uiProps.seekToSecondsCommand.perform(with: value - min(value, 10))
+        uiProps.seekToSecondsAction.perform(with: value - min(value, 10))
         onUserInteraction?.perform()
     }
     
@@ -342,16 +342,16 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     }
     
     @IBAction private func retry() {
-        uiProps.retryButtonCommand.perform()
+        uiProps.retryButtonAction.perform()
         onUserInteraction?.perform()
     }
     
     @IBAction private func pipButtonTouched() {
-        uiProps.pipButtonCommand.perform()
+        uiProps.pipButtonAction.perform()
         onUserInteraction?.perform()
     }
     
     @IBAction private func settingsButtonTouched() {
-        uiProps.settingsButtonCommand.perform()
+        uiProps.settingsButtonAction.perform()
     }
 }

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -69,7 +69,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             sideBarView.props = sidebarProps.map { [weak self] in
                 var props = $0
                 let handler = props.handler
-                props.handler = .init {
+                props.handler = CommandWith {
                     self?.onUserInteraction?.perform()
                     handler.perform()
                 }
@@ -80,13 +80,13 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     
     public override func viewDidLoad() {
         super.viewDidLoad()
-        seekerView.callbacks.onDragStarted = .init { [unowned self] value in
+        seekerView.callbacks.onDragStarted = CommandWith { [unowned self] value in
             self.startSeek(from: value)
         }
-        seekerView.callbacks.onDragChanged = .init { [unowned self] value in
+        seekerView.callbacks.onDragChanged = CommandWith { [unowned self] value in
             self.updateSeek(to: value)
         }
-        seekerView.callbacks.onDragFinished = .init { [unowned self] value in
+        seekerView.callbacks.onDragFinished = CommandWith { [unowned self] value in
             self.stopSeek(at: value)
         }
     }

--- a/PlayerControls/sources/SeekerControlView.swift
+++ b/PlayerControls/sources/SeekerControlView.swift
@@ -141,18 +141,18 @@ final class SeekerControlView: UIView {
         }
     }
     struct Callbacks {
-        var onDragStarted: Action<CGFloat>?
-        var onDragChanged: Action<CGFloat>?
-        var onDragFinished: Action<CGFloat>?
+        var onDragStarted: CommandWith<CGFloat>?
+        var onDragChanged: CommandWith<CGFloat>?
+        var onDragFinished: CommandWith<CGFloat>?
     }
     
     var callbacks: Callbacks = Callbacks()
     
     func ringIsDragged(recognizer: SeekGestureRecognizer) {
         switch recognizer.state {
-        case .began: callbacks.onDragStarted?(recognizer.progress)
-        case .changed: callbacks.onDragChanged?(recognizer.progress)
-        case .ended, .possible: callbacks.onDragFinished?(recognizer.progress)
+        case .began: callbacks.onDragStarted?.perform(with: recognizer.progress)
+        case .changed: callbacks.onDragChanged?.perform(with: recognizer.progress)
+        case .ended, .possible: callbacks.onDragFinished?.perform(with: recognizer.progress)
         default: break }
     }
     

--- a/PlayerControls/sources/SettingsViewController+TableView.swift
+++ b/PlayerControls/sources/SettingsViewController+TableView.swift
@@ -82,7 +82,7 @@ extension SettingsViewController: UITableViewDelegate {
             fatalError("Cell not found!")
         }
         
-        cell.select()
+        cell.select.perform()
     }
 }
 

--- a/PlayerControls/sources/SettingsViewController.swift
+++ b/PlayerControls/sources/SettingsViewController.swift
@@ -9,7 +9,7 @@ public class SettingsViewController: UIViewController {
     @IBOutlet var tableViewHeightConstraint: NSLayoutConstraint!
     
     @IBAction func closeButtonTouched(_ sender: Any) {
-        props?.dismissAction.perform()
+        props?.dismissCommand.perform()
     }
     
     public init() {
@@ -44,7 +44,7 @@ extension SettingsViewController {
         }
         
         public let sections: [Section]
-        public let dismissAction: Command
+        public let dismissCommand: Command
     }
 }
 
@@ -52,7 +52,7 @@ extension ContentControlsViewController {
     public static func settingProps(from props: Props) -> SettingsViewController.Props? {        
         guard case .player(let player) = props else { return nil }
         guard case .playable(let controls) = player.item else { return nil }
-        guard case .enabled(let action) = controls.settings else { return nil }
+        guard case .enabled(let command) = controls.settings else { return nil }
         
         var sections: [SettingsViewController.Props.Section] = []
     
@@ -84,6 +84,6 @@ extension ContentControlsViewController {
         
         return SettingsViewController.Props(
             sections: sections,
-            dismissAction: action)
+            dismissCommand: command)
     }
 }

--- a/PlayerControls/sources/SettingsViewController.swift
+++ b/PlayerControls/sources/SettingsViewController.swift
@@ -9,7 +9,7 @@ public class SettingsViewController: UIViewController {
     @IBOutlet var tableViewHeightConstraint: NSLayoutConstraint!
     
     @IBAction func closeButtonTouched(_ sender: Any) {
-        props?.dismissAction()
+        props?.dismissAction.perform()
     }
     
     public init() {
@@ -40,11 +40,11 @@ extension SettingsViewController {
         public struct Cell {
             public let title: String
             public let selected: Bool
-            public let select: Action<Void>
+            public let select: Command
         }
         
         public let sections: [Section]
-        public let dismissAction: Action<Void>
+        public let dismissAction: Command
     }
 }
 
@@ -67,7 +67,7 @@ extension ContentControlsViewController {
                         SettingsViewController.Props.Cell(
                             title: $0.name,
                             selected: $0.selected,
-                            select: $0.select)
+                            select: $0.select!)
                 }))
         }
         

--- a/PlayerControls/sources/SettingsViewController.swift
+++ b/PlayerControls/sources/SettingsViewController.swift
@@ -9,7 +9,7 @@ public class SettingsViewController: UIViewController {
     @IBOutlet var tableViewHeightConstraint: NSLayoutConstraint!
     
     @IBAction func closeButtonTouched(_ sender: Any) {
-        props?.dismissCommand.perform()
+        props?.dismissAction.perform()
     }
     
     public init() {
@@ -44,7 +44,7 @@ extension SettingsViewController {
         }
         
         public let sections: [Section]
-        public let dismissCommand: Command
+        public let dismissAction: Command
     }
 }
 
@@ -52,7 +52,7 @@ extension ContentControlsViewController {
     public static func settingProps(from props: Props) -> SettingsViewController.Props? {        
         guard case .player(let player) = props else { return nil }
         guard case .playable(let controls) = player.item else { return nil }
-        guard case .enabled(let command) = controls.settings else { return nil }
+        guard case .enabled(let action) = controls.settings else { return nil }
         
         var sections: [SettingsViewController.Props.Section] = []
     
@@ -84,6 +84,6 @@ extension ContentControlsViewController {
         
         return SettingsViewController.Props(
             sections: sections,
-            dismissCommand: command)
+            dismissAction: action)
     }
 }

--- a/PlayerControls/sources/SettingsViewController.swift
+++ b/PlayerControls/sources/SettingsViewController.swift
@@ -67,7 +67,7 @@ extension ContentControlsViewController {
                         SettingsViewController.Props.Cell(
                             title: $0.name,
                             selected: $0.selected,
-                            select: $0.select!)
+                            select: $0.select)
                 }))
         }
         

--- a/PlayerControls/sources/SideBarView.swift
+++ b/PlayerControls/sources/SideBarView.swift
@@ -48,13 +48,13 @@ public final class SideBarView: UIView {
         }
         
         /// Touch handler for button.
-        public var handler: Action<Void>
+        public var handler: Command
         
         /// Public constructor.
         public init(isEnabled: Bool,
                     isSelected: Bool,
                     icons: Icons,
-                    handler: @escaping Action<Void>) {
+                    handler: Command) {
             self.isEnabled = isEnabled
             self.isSelected = isSelected
             self.icons = icons
@@ -69,7 +69,7 @@ public final class SideBarView: UIView {
                 normal: UIImage(),
                 selected: nil,
                 highlighted: nil),
-            handler: {})
+            handler: .nop)
     }
     var buttons: [UIButton] = []
     
@@ -77,7 +77,7 @@ public final class SideBarView: UIView {
         guard let index = buttons.index(of: sender) else {
             fatalError("Not found button in array!")
         }
-        props[index].handler()
+        props[index].handler.perform()
     }
     
     var props: SideBarView.Props = [] {
@@ -175,3 +175,5 @@ extension SideBarView {
         return totalSpace / spacingCount
     }
 }
+
+

--- a/PlayerControls/sources/Timer.swift
+++ b/PlayerControls/sources/Timer.swift
@@ -4,9 +4,9 @@ import Foundation
 
 public class Timer {
     private var timer: Foundation.Timer!
-    private let fire: Action<Void>
-    public init(duration: TimeInterval, fire: @escaping Action<Void>) {
-        self.fire = fire
+    private let fire: Command
+    public init(duration: TimeInterval, fire: Command?) {
+        self.fire = fire!
         self.timer = Foundation.Timer(timeInterval: duration,
                                       target: self,
                                       selector: #selector(onFire),
@@ -17,7 +17,7 @@ public class Timer {
     }
     
     @objc private func onFire() {
-        fire()
+        fire.perform()
     }
     
     func cancel() {

--- a/PlayerControls/sources/Timer.swift
+++ b/PlayerControls/sources/Timer.swift
@@ -5,8 +5,8 @@ import Foundation
 public class Timer {
     private var timer: Foundation.Timer!
     private let fire: Command
-    public init(duration: TimeInterval, fire: Command?) {
-        self.fire = fire!
+    public init(duration: TimeInterval, fire: Command) {
+        self.fire = fire
         self.timer = Foundation.Timer(timeInterval: duration,
                                       target: self,
                                       selector: #selector(onFire),

--- a/PlayerControls/sources/Utils.swift
+++ b/PlayerControls/sources/Utils.swift
@@ -1,15 +1,5 @@
 //  Copyright © 2017 One by AOL : Publishers. All rights reserved.
 
-public typealias Action<T> = (T) -> Void
-
-func nop<T>() -> Action<T> {
-    return { _ in }
-}
-
-func nop<T>(t: T) { }
-
-func nop() { }
-
 extension UIImageView {
     func enableRotation() {
         /* Configure loading animation. */ do {


### PR DESCRIPTION
## Command - replacement of Actions (closures)
This new type was added to replace our old implementation of closures usage. 
CommandWith is a generic struct with type T, where T is a closure that you send.
To present your variable as a Command, you should specify its type. By default, Command has an empty closure that doesn't receives and doesn't returns anything:`(Void) -> (Void)`. To use any other type as a received one, you should specify it as `CommandWith<Type>`.
