### PR TITLE
Fix live dot color changing

### DIFF
--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -193,7 +193,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         settingsButton.isEnabled = uiProps.settingsButtonEnabled
         
         liveIndicationView.isHidden = uiProps.liveIndicationViewIsHidden
-        liveDotLabel.textColor = uiProps.liveDotColor ?? view.tintColor
+        liveDotLabel.textColor = uiProps.liveDotColor ?? liveDotLabel.textColor ?? view.tintColor
         
         airplayActiveLabel.isHidden = uiProps.airplayActiveLabelHidden
         airPlayView.props = AirPlayView.Props(


### PR DESCRIPTION
Proposed to check is `liveDotLabel.textColor` not nill and use this value.
**Reason**: If set `controls.live.dotColor` on init when player is updated it will become nill because `ContentControlsViewController+Binding` contains 
```
return Controls.Live {
  $0.isHidden = !item.content.time.isLive
  $0.dotColor = nil
}
```

[JIRA Issue](https://jira.ops.aol.com/browse/OMSDK-447)