### PR TITLE
Added Command in controls visibility controller tests

### DIFF
--- a/PlayerControls/tests/ControlsVisibilityControllerTests.swift
+++ b/PlayerControls/tests/ControlsVisibilityControllerTests.swift
@@ -12,11 +12,11 @@ class ControlsVisibilityControllerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         controls = ControlsPresentationController.Controls(
-            show: recorder.hook("show controls"),
-            hide: recorder.hook("hide controls"))
+            show: CommandWith { [weak self] in self?.recorder.hook("show controls")() },
+            hide: CommandWith { [weak self] in self?.recorder.hook("hide controls")() })
         timer = ControlsPresentationController.Timer(
-            start: recorder.hook("start timer"),
-            stop: recorder.hook("end timer"))
+            start: CommandWith { [weak self] in self?.recorder.hook("start timer")() },
+            stop: CommandWith { [weak self] in self?.recorder.hook("end timer")() })
         controller = ControlsPresentationController(controls: controls, timer: timer)
     }
     
@@ -32,46 +32,46 @@ class ControlsVisibilityControllerTests: XCTestCase {
         }
         
         recorder.verify {
-            controls.show()
+            controls.show.perform()
         }
     }
     
     
     func testHideOnTap() {
         recorder.record { controller.tap() }
-        recorder.verify { controls.hide() }
+        recorder.verify { controls.hide.perform() }
     }
     
     func testStartTimerOnPlay() {
         recorder.record { controller.play() }
-        recorder.verify { timer.start() }
+        recorder.verify { timer.start.perform() }
     }
     
     func testPlayingShouldHideOnTimerFire() {
         controller.play()
         recorder.record { controller.timerFired() }
-        recorder.verify { controls.hide() }
+        recorder.verify { controls.hide.perform() }
     }
     
     func testPlayingShouldStopTimerOnPause() {
         controller.play()
         recorder.record { controller.pause() }
-        recorder.verify { timer.stop() }
+        recorder.verify { timer.stop.perform() }
     }
     
     func testPlayingShouldHideAndStopOnTap() {
         controller.play()
         recorder.record { controller.tap() }
         recorder.verify {
-            timer.stop()
-            controls.hide()
+            timer.stop.perform()
+            controls.hide.perform()
         }
     }
     
     func testPausedAndHiddenShouldShowControlsByTap() {
         controller.tap()
         recorder.record { controller.tap() }
-        recorder.verify { controls.show() }
+        recorder.verify { controls.show.perform() }
     }
     
     func testPausedAndHiddenShouldStartPlayingVideo() {
@@ -84,7 +84,7 @@ class ControlsVisibilityControllerTests: XCTestCase {
         controller.tap()
         controller.play()
         recorder.record { controller.pause() }
-        recorder.verify { controls.show() }
+        recorder.verify { controls.show.perform() }
     }
     
     func testPlayingAndHiddenShouldStartTimerAndShowOnTap() {
@@ -92,8 +92,8 @@ class ControlsVisibilityControllerTests: XCTestCase {
         controller.play()
         recorder.record { controller.tap() }
         recorder.verify {
-            controls.show()
-            timer.start()
+            controls.show.perform()
+            timer.start.perform()
         }
     }
 }

--- a/PlayerControls/tests/ControlsVisibilityControllerTests.swift
+++ b/PlayerControls/tests/ControlsVisibilityControllerTests.swift
@@ -12,11 +12,11 @@ class ControlsVisibilityControllerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         controls = ControlsPresentationController.Controls(
-            show: CommandWith { [weak self] in self?.recorder.hook("show controls")() },
-            hide: CommandWith { [weak self] in self?.recorder.hook("hide controls")() })
+            show: CommandWith(action: recorder.hook("show controls")),
+            hide: CommandWith(action: recorder.hook("hide controls")))
         timer = ControlsPresentationController.Timer(
-            start: CommandWith { [weak self] in self?.recorder.hook("start timer")() },
-            stop: CommandWith { [weak self] in self?.recorder.hook("end timer")() })
+            start: CommandWith(action: recorder.hook("start timer")),
+            stop: CommandWith(action: recorder.hook("end timer")))
         controller = ControlsPresentationController(controls: controls, timer: timer)
     }
     


### PR DESCRIPTION
## Added Command in controls visibility controller Tests
A hot fix for our tests of controls visibility. After adding a `Command` to a project, it was now added to our `Recorder` instead of closures that have to return `Command` to match requested type. Those closures, that are used only in `Recorder` were not changed.
Also, in `ControlsVisibilityControllerTests`, all Commands perform actions that they contain and now all our tests pass.