### PR TITLE
Fixed EnumPrism.stencil crash after Sourcery update

### DIFF
--- a/PlayerControls/templates/EnumPrism.stencil
+++ b/PlayerControls/templates/EnumPrism.stencil
@@ -53,7 +53,7 @@ import Foundation
 
 /*Creates Bool var with given simple case*/
 {% macro simpleVar case %}
-    public var is{{ case.name|upperFirst }}: Bool {
+    public var is{{ case.name|capitalize }}: Bool {
         guard case .{{ case.name }} = self else { return false }
         return true
     }


### PR DESCRIPTION
## Updated filter name from upperFirst on capitalize
Sourcery of version 0.10.0 has broken our Stencil prism. They've removed their filters, including `upperFirst` and now they are using filters from StencilSwiftKit. This change caused an error while the stencil file was compiled, because it wasn't able to find the `upperFirst` filter. 
Now this filter is called `capitalize` and it is added to our enum prism.