### PR TITLE
Initializers  for ContentControlsViewController Props

### DIFF
--- a/Demo/Demo/AppDelegate.swift
+++ b/Demo/Demo/AppDelegate.swift
@@ -5,25 +5,52 @@ import PlayerControls
 
 typealias Props = ContentControlsViewController.Props
 func props() -> Props {
-    return Props.player(Props.Player { player in
-        player.item = Props.Player.Item.playable(Props.Player.Item.Controls { controls in
-            controls.title = "Some title very very very very very very very very very long"
-            controls.live.isHidden = true
-            controls.seekbar = .init()
-            controls.playbackAction = .pause(.nop)
-            controls.camera = Props.Player.Item.Controls.Camera()
-            controls.settings = .hidden
-            controls.pictureInPictureControl = .unsupported
-            controls.legible = .`internal`(nil)
-            controls.title = ""
-            controls.airplay = .enabled
-        })
-    })
+    return Props.player(Props.Player(
+        playlist: Props.Playlist(
+            next: nil,
+            prev: nil),
+        item: .playable(Props.Controls(
+            airplay: .enabled,
+            audible: Props.MediaGroupControl(options: []),
+            camera: Props.Camera(
+                angles: Props.Angles(
+                    horizontal: 0.0,
+                    vertical: 0.0),
+                moveTo: .nop),
+            error: nil,
+            legible: .external(
+                external: .available(state: .active(text: "Somthing short")),
+                control: Props.MediaGroupControl(options: [Props.Option(
+                    name: "Option1",
+                    selected: true,
+                    select: .nop)])),
+            live: Props.Live(
+                isHidden: false,
+                dotColor: nil),
+            loading: false,
+            pictureInPictureControl: .possible(.nop),
+            playbackAction: .play(.nop),
+            seekbar: Props.Seekbar(
+                duration: 3600,
+                currentTime: 1800,
+                progress: 0.5,
+                buffered: 0.7,
+                seeker: Props.Seeker(
+                    seekTo: .nop,
+                    state: Props.State(
+                        start: .nop,
+                        update: .nop,
+                        stop: .nop))),
+            settings: .enabled(.nop),
+            sideBarViewHidden: true,
+            thumbnail: nil,
+            title: "Long titel"))))
 }
+
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
+    
     var window: UIWindow?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
@@ -40,4 +67,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 }
+
+
 

--- a/PlayerControls/PlayerControls.xcodeproj/project.pbxproj
+++ b/PlayerControls/PlayerControls.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		0696270D1FD188A50098494A /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0696270C1FD188A50098494A /* Command.swift */; };
+		42A7F6581FEC156400CE39C0 /* Defaultable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A7F6571FEC156400CE39C0 /* Defaultable.swift */; };
+		42A7F65A1FEC230D00CE39C0 /* ContentControlsUIProps+Init.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A7F6591FEC230D00CE39C0 /* ContentControlsUIProps+Init.swift */; };
 		50582F6C1E65C64B00B18908 /* ContentControlsUIProps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50582F671E65C64B00B18908 /* ContentControlsUIProps.swift */; };
 		50582F6E1E65C64B00B18908 /* ContentControlsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50582F691E65C64B00B18908 /* ContentControlsViewController.swift */; };
 		50582F6F1E65C64B00B18908 /* DefaultControlsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50582F6A1E65C64B00B18908 /* DefaultControlsViewController.swift */; };
@@ -28,7 +30,6 @@
 		50582FAA1E65DC1600B18908 /* FormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50582F831E65CA5F00B18908 /* FormatterTests.swift */; };
 		50582FAB1E65DC1600B18908 /* SideBarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50582F761E65C8CC00B18908 /* SideBarViewTests.swift */; };
 		50582FB21E65DEF800B18908 /* Recorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50582FB11E65DEF800B18908 /* Recorder.swift */; };
-		50582FC41E67086000B18908 /* Defaultable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50582FC31E67086000B18908 /* Defaultable.swift */; };
 		50A5A5B51E6F13A900C15E12 /* PlayerUIControls.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 50A5A5B41E6F13A900C15E12 /* PlayerUIControls.xcassets */; };
 		50F471351F5958E900C35AEF /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50F471341F5958E900C35AEF /* SettingsViewController.swift */; };
 		50F471371F59590B00C35AEF /* SettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 50F471361F59590B00C35AEF /* SettingsViewController.xib */; };
@@ -69,6 +70,8 @@
 
 /* Begin PBXFileReference section */
 		0696270C1FD188A50098494A /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
+		42A7F6571FEC156400CE39C0 /* Defaultable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Defaultable.swift; sourceTree = "<group>"; };
+		42A7F6591FEC230D00CE39C0 /* ContentControlsUIProps+Init.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentControlsUIProps+Init.swift"; sourceTree = "<group>"; };
 		50582F5B1E65C41900B18908 /* PlayerControls.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PlayerControls.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		50582F5F1E65C41900B18908 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		50582F671E65C64B00B18908 /* ContentControlsUIProps.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentControlsUIProps.swift; sourceTree = "<group>"; };
@@ -92,7 +95,6 @@
 		50582F9E1E65D78C00B18908 /* PlayerControlsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PlayerControlsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		50582FA21E65D78C00B18908 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = tests/Info.plist; sourceTree = SOURCE_ROOT; };
 		50582FB11E65DEF800B18908 /* Recorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Recorder.swift; path = tests/Recorder.swift; sourceTree = SOURCE_ROOT; };
-		50582FC31E67086000B18908 /* Defaultable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Defaultable.swift; sourceTree = "<group>"; };
 		50A5A5B41E6F13A900C15E12 /* PlayerUIControls.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = PlayerUIControls.xcassets; path = resources/PlayerUIControls.xcassets; sourceTree = SOURCE_ROOT; };
 		50F471341F5958E900C35AEF /* SettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		50F471361F59590B00C35AEF /* SettingsViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = SettingsViewController.xib; path = resources/SettingsViewController.xib; sourceTree = SOURCE_ROOT; };
@@ -205,6 +207,7 @@
 				50582F921E65CD8500B18908 /* side bar */,
 				50582F671E65C64B00B18908 /* ContentControlsUIProps.swift */,
 				50582F691E65C64B00B18908 /* ContentControlsViewController.swift */,
+				42A7F6591FEC230D00CE39C0 /* ContentControlsUIProps+Init.swift */,
 				50582F911E65CD7B00B18908 /* default */,
 			);
 			name = "content controls";
@@ -259,9 +262,9 @@
 			isa = PBXGroup;
 			children = (
 				50582F731E65C79D00B18908 /* Utils.swift */,
+				42A7F6571FEC156400CE39C0 /* Defaultable.swift */,
 				0696270C1FD188A50098494A /* Command.swift */,
 				50582FB11E65DEF800B18908 /* Recorder.swift */,
-				50582FC31E67086000B18908 /* Defaultable.swift */,
 			);
 			name = utils;
 			sourceTree = "<group>";
@@ -443,15 +446,16 @@
 				50F471591F5D763500C35AEF /* SettingHeaderView.swift in Sources */,
 				50582F861E65CA5F00B18908 /* TimeFormatter.swift in Sources */,
 				50582F6F1E65C64B00B18908 /* DefaultControlsViewController.swift in Sources */,
+				42A7F6581FEC156400CE39C0 /* Defaultable.swift in Sources */,
 				50582F741E65C79D00B18908 /* Utils.swift in Sources */,
 				DA070BB11F8B776A007F407D /* AirPlayView.swift in Sources */,
 				50582F771E65C8CC00B18908 /* SideBarView.swift in Sources */,
 				50F4713B1F5980A000C35AEF /* SettingCell.swift in Sources */,
 				50582F8A1E65CBE600B18908 /* ControlsVisibilityController.swift in Sources */,
 				DA036B641FB20BBB00BD0728 /* AirPlayActiveView.swift in Sources */,
+				42A7F65A1FEC230D00CE39C0 /* ContentControlsUIProps+Init.swift in Sources */,
 				50F471351F5958E900C35AEF /* SettingsViewController.swift in Sources */,
 				50F471391F597F0700C35AEF /* SettingsViewController+TableView.swift in Sources */,
-				50582FC41E67086000B18908 /* Defaultable.swift in Sources */,
 				50582F6C1E65C64B00B18908 /* ContentControlsUIProps.swift in Sources */,
 				50582F7C1E65C93400B18908 /* SeekerControlView.swift in Sources */,
 			);

--- a/PlayerControls/sources/ContentControlsUIProps+Init.swift
+++ b/PlayerControls/sources/ContentControlsUIProps+Init.swift
@@ -1,0 +1,127 @@
+//
+//  Inits.swift
+//  PlayerControls
+//
+//  Created by Andrey Doroshko on 12/21/17.
+//  Copyright © 2017 One by AOL : Publishers. All rights reserved.
+//
+
+import Foundation
+private typealias Props = ContentControlsViewController.Props
+
+extension Props.Player {
+    public init(playlist: Props.Playlist?, item: Props.Item) {
+        self.playlist = playlist
+        self.item = item
+    }
+}
+
+extension Props.Playlist {
+    public init(next: Command?, prev: Command?) {
+        self.next = next
+        self.prev = prev
+    }
+}
+
+extension Props.Controls {
+    public init(airplay: Props.AirPlay,
+                audible: Props.MediaGroupControl?,
+                camera: Props.Camera?,
+                error: Props.Error?,
+                legible: Props.Subtitles,
+                live: Props.Live,
+                loading: Bool,
+                pictureInPictureControl: Props.PictureInPictureControl,
+                playbackAction: Props.Playback,
+                seekbar: Props.Seekbar,
+                settings: Props.Settings,
+                sideBarViewHidden: Bool,
+                thumbnail: Props.Thumbnail?,
+                title: String) {
+        self.title = title
+        self.thumbnail = thumbnail
+        self.sideBarViewHidden = sideBarViewHidden
+        self.settings = settings
+        self.seekbar = seekbar
+        self.playbackAction = playbackAction
+        self.pictureInPictureControl = pictureInPictureControl
+        self.loading = loading
+        self.live = live
+        self.legible = legible
+        self.camera = camera
+        self.error = error
+        self.audible = audible
+        self.airplay = airplay
+    }
+}
+
+extension Props.Angles {
+    public init(horizontal: Float, vertical: Float) {
+        self.horizontal = horizontal
+        self.vertical = vertical
+    }
+}
+
+extension Props.Camera {
+    public init(angles: Props.Angles, moveTo: CommandWith<Props.Angles>) {
+        self.angles = angles
+        self.moveTo = moveTo
+    }
+}
+
+extension Props.Error {
+    public init(message: String, retryAction: Command?) {
+        self.message = message
+        self.retryAction = retryAction
+    }
+}
+
+extension Props.Live {
+    public init(isHidden: Bool, dotColor: UIColor?) {
+        self.isHidden = isHidden
+        self.dotColor = dotColor
+    }
+}
+
+extension Props.MediaGroupControl {
+    public init(options: [Props.Option]) {
+        self.options = options
+    }
+}
+
+extension Props.Option {
+    public init(name: String ,
+                selected: Bool,
+                select: Command) {
+        self.name = name
+        self.selected = selected
+        self.select = select
+    }
+}
+
+extension Props.Seekbar {
+    public init(duration: Props.Seconds, currentTime: Props.Seconds, progress: Props.Progress, buffered: Props.Progress, seeker: Props.Seeker) {
+        self.duration = duration
+        self.currentTime = currentTime
+        self.progress = progress
+        self.buffered = buffered
+        self.seeker = seeker
+    }
+}
+
+extension Props.State {
+    public init(start: CommandWith<Props.Progress>,
+                update: CommandWith<Props.Progress>,
+                stop: CommandWith<Props.Progress>) {
+        self.start = start
+        self.update = update
+        self.stop = stop
+    }
+}
+
+extension Props.Seeker {
+    public init(seekTo: CommandWith<Props.Seconds>?, state: Props.State) {
+        self.seekTo = seekTo
+        self.state = state
+    }
+}

--- a/PlayerControls/sources/ContentControlsUIProps.swift
+++ b/PlayerControls/sources/ContentControlsUIProps.swift
@@ -182,11 +182,11 @@ extension DefaultControlsViewController {
             
             resetCameraAngles = {
                 guard let camera = props.player?.item.playable?.camera else { return .nop }
-                return camera.moveTo.bind(to: .init())
+                return camera.moveTo.bind(to: .init(horizontal: 0.0, vertical: 0.0))
             }()
             
             cameraPanGestureIsEnabled = props.player?.item.playable?.camera != nil
-            
+        
             videoTitleLabelHidden = props.player?.item.playable == nil
             
             videoTitleLabelText = props.player?.item.playable?.title ?? ""

--- a/PlayerControls/sources/ContentControlsViewController.swift
+++ b/PlayerControls/sources/ContentControlsViewController.swift
@@ -1,7 +1,6 @@
 //  Copyright © 2016 One by Aol : Publishers. All rights reserved.
 
 import Foundation
-
 ///Generate prism for confirmed enum 
 public protocol Prism {}
 /// Base class for implementing custom content
@@ -25,156 +24,165 @@ open class ContentControlsViewController: UIViewController {
         
         public struct Player {
             public var playlist: Playlist?
-            public struct Playlist {
-                public var next: Command?
-                public var prev: Command?
-                public init() { }
-            }
+            public var item: Item = .nonplayable("")
             
-            public var item = Item.nonplayable("")
+            public init() {}
+        }
+        
+        public struct Playlist {
+            public var next: Command?
+            public var prev: Command?
             
-            public enum Item: Prism {
-                case playable(Controls)
-                case nonplayable(String)
-            }
-            
-            public init() { }
+            public init() {}
+        }
+        
+        public enum Item: Prism {
+            case playable(Controls)
+            case nonplayable(String)
         }
     }
 }
 
-extension ContentControlsViewController.Props.Player.Item {
+extension ContentControlsViewController.Props {
+    public typealias Seconds = Int
+    public typealias Progress = Double
+    
     public struct Controls {
-        public var title = ""
-        public var loading = false
         
+        public var title: String = ""
+        public var loading: Bool = false
         public var playbackAction: Playback = .none
-            public enum Playback: Prism {
-            case none
-            case play(Command)
-            case pause(Command)
-            case replay(Command)
-        }
-        
-        public var live = Live()
-        public struct Live {
-            public var isHidden = true
-            public var dotColor: UIColor?
-            public init() { }
-        }
+        public var live: Live = Live()
         public var seekbar: Seekbar?
-        public struct Seekbar {
-            public typealias Seconds = Int
-            public typealias Progress = Double
-            
-            public var duration: Seconds = 0
-            public var currentTime: Seconds = 0
-            public var progress: Progress = 0.0
-            public var buffered: Progress = 0.0
-            
-            public var seeker = Seeker()
-            
-            public struct Seeker {
-                public var seekTo: CommandWith<Seconds>?
-                
-                public var state = State()
-                public struct State {
-                    public var start: CommandWith<Progress> = .nop
-                    public var update: CommandWith<Progress> = .nop
-                    public var stop: CommandWith<Progress> = .nop
-                    public init() { }
-                }
-                public init() { }
-            }
-            public init() { }
-        }
-        
         /// This field will be available only when 360 video is active
         public var camera: Camera?
-        public struct Camera {
-            /// Angles of current camera position - measured in radians.
-            public struct Angles {
-                
-                /// zero - center, positive - right part, negative - left part.
-                public var horizontal: Float = 0.0
-                
-                /// zero - horizon, positive - above horizon, negative - below
-                public var vertical: Float = 0.0
-                public init() { }
-            }
-            
-            public var angles = Angles()
-            public var moveTo: CommandWith<Angles> = .nop
-            public init() { }
-        }
-        
         /// URL or UIImage for the thumbnail.
         public var thumbnail: Thumbnail?
-        public enum Thumbnail: Prism {
-            case url(URL) //swiftlint:disable:this type_name
-            case image(UIImage)
-        }
-        
-        
-        public var sideBarViewHidden = true
-        
+        public var sideBarViewHidden: Bool = true
         public var error: Error?
-        public struct Error {
-            public var message = ""
-            public var retryAction: Command?
-            public init() { }
-        }
-        
-        public var pictureInPictureControl: PictureInPictureControl = .unsupported
-        public enum PictureInPictureControl: Prism {
-            case unsupported
-            case impossible
-            case possible(Command)
-        }
-        
-        public enum Subtitles: Prism {
-            case `internal`(MediaGroupControl?)
-            case external(external: External, control: MediaGroupControl)
-            
-            public enum External: Prism {
-                case none
-                case unavailable
-                case available(state: State)
-                public enum State: Prism {
-                    case active(text: String?), loading, inactive, error
-                }
-            }
-        }
-        
-        public struct MediaGroupControl {
-            public var options: [Option] = []
-            public struct Option {
-                public var name = ""
-                public var selected = false
-                public var select: Command = .nop
-                public init() { }
-            }
-            
-            public init() { }
-        }
-        
-        public var legible: Subtitles = .`internal`(nil)
+        public var pictureInPictureControl: PictureInPictureControl = .impossible
+        public var legible: Subtitles = .internal(nil)
         public var audible: MediaGroupControl?
-        
-        public enum Settings: Prism {
-            case hidden
-            case disabled
-            case enabled(Command)
-        }
         public var settings: Settings = .disabled
+        public var airplay: AirPlay = .enabled
+
+        public init() {}
+    }
+    
+    public struct Angles {
+        /// zero - center, positive - right part, negative - left part.
+        public var horizontal: Float = 0.0
+        /// zero - horizon, positive - above horizon, negative - below
+        public var vertical: Float = 0.0
         
-        public enum AirPlay: Prism {
-            case hidden
-            case enabled
-            case active
+        public init() {}
+    }
+    
+    public enum AirPlay: Prism {
+        case hidden
+        case enabled
+        case active
+    }
+    
+    public struct Camera {
+        /// Angles of current camera position - measured in radians.
+        public var angles: Angles = Angles()
+        public var moveTo: CommandWith<Angles> = .nop
+
+        public init() {}
+    }
+    
+    public enum External: Prism {
+        case none
+        case unavailable
+        case available(state: State)
+        
+        public enum State: Prism {
+            case active(text: String?), loading, inactive, error
         }
-        public var airplay: AirPlay = .hidden
+    }
+    
+    public struct Error {
+        public var message: String = ""
+        public var retryAction: Command?
         
-        public init() { }
+        public init() {}
+    }
+    
+    public struct Live {
+        public var isHidden: Bool = true
+        public var dotColor: UIColor?
+        
+        public init() {}
+    }
+    
+    public struct MediaGroupControl {
+        public var options: [Option] = []
+        
+        public init() {}
+    }
+    
+    public struct Option {
+        public var name: String = ""
+        public var selected: Bool = false
+        public var select: Command = .nop
+        
+        public init() {}
+    }
+    
+    public enum PictureInPictureControl: Prism {
+        case unsupported
+        case impossible
+        case possible(Command)
+    }
+    
+    public enum Playback: Prism {
+        case none
+        case play(Command)
+        case pause(Command)
+        case replay(Command)
+    }
+    
+    public struct Seekbar {
+        public var duration: Seconds = 0
+        public var currentTime: Seconds = 0
+        public var progress: Progress = 0
+        public var buffered: Progress = 0
+        public var seeker: Seeker = Seeker()
+    
+        public init() {}
+    }
+    
+    public struct State {
+        public var start: CommandWith<Progress> = .nop
+        public var update: CommandWith<Progress> = .nop
+        public var stop: CommandWith<Progress> = .nop
+        
+        public init() {}
+    }
+    
+    public struct Seeker {
+        public var seekTo: CommandWith<Seconds>?
+        public var state: State = State()
+        
+        public init() {}
+    }
+    
+    public enum Subtitles: Prism {
+        case `internal`(MediaGroupControl?)
+        case external(external: External, control: MediaGroupControl)
+    }
+    
+    public enum Settings: Prism {
+        case hidden
+        case disabled
+        case enabled(Command)
+    }
+    
+    public enum Thumbnail: Prism {
+        case url(URL) //swiftlint:disable:this type_name
+        case image(UIImage)
     }
 }
+
+

--- a/PlayerControls/sources/Defaultable.swift
+++ b/PlayerControls/sources/Defaultable.swift
@@ -12,14 +12,14 @@ extension Defaultable {
 }
 
 extension ContentControlsViewController.Props.Player: Defaultable { }
-extension ContentControlsViewController.Props.Player.Item.Controls.Seekbar: Defaultable { }
-extension ContentControlsViewController.Props.Player.Item.Controls.Seekbar.Seeker: Defaultable { }
-extension ContentControlsViewController.Props.Player.Item.Controls.Seekbar.Seeker.State: Defaultable { }
-extension ContentControlsViewController.Props.Player.Item.Controls.Live: Defaultable { }
-extension ContentControlsViewController.Props.Player.Item.Controls.Camera: Defaultable { }
-extension ContentControlsViewController.Props.Player.Item.Controls.Camera.Angles: Defaultable { }
-extension ContentControlsViewController.Props.Player.Item.Controls.Error: Defaultable { }
-extension ContentControlsViewController.Props.Player.Item.Controls: Defaultable { }
-extension ContentControlsViewController.Props.Player.Item.Controls.MediaGroupControl: Defaultable { }
-extension ContentControlsViewController.Props.Player.Item.Controls.MediaGroupControl.Option: Defaultable { }
-extension ContentControlsViewController.Props.Player.Playlist: Defaultable { }
+extension ContentControlsViewController.Props.Seekbar: Defaultable { }
+extension ContentControlsViewController.Props.Seeker: Defaultable { }
+extension ContentControlsViewController.Props.State: Defaultable { }
+extension ContentControlsViewController.Props.Live: Defaultable { }
+extension ContentControlsViewController.Props.Camera: Defaultable { }
+extension ContentControlsViewController.Props.Angles: Defaultable { }
+extension ContentControlsViewController.Props.Error: Defaultable { }
+extension ContentControlsViewController.Props.Controls: Defaultable { }
+extension ContentControlsViewController.Props.MediaGroupControl: Defaultable { }
+extension ContentControlsViewController.Props.Option: Defaultable { }
+extension ContentControlsViewController.Props.Playlist: Defaultable { }

--- a/PlayerControls/sources/SettingsViewController.swift
+++ b/PlayerControls/sources/SettingsViewController.swift
@@ -57,7 +57,7 @@ extension ContentControlsViewController {
         var sections: [SettingsViewController.Props.Section] = []
     
         func appendSection(with title: String,
-                           group: Props.Player.Item.Controls.MediaGroupControl?) {
+                           group: Props.MediaGroupControl?) {
             guard let group = group else { return }
             guard group.options.count > 1 else { return }
             sections.append(

--- a/PlayerControls/sources/SideBarView.swift
+++ b/PlayerControls/sources/SideBarView.swift
@@ -30,7 +30,8 @@ public final class SideBarView: UIView {
         public var isSelected: Bool
         
         /// Button icons.
-        public var icons: Icons; public struct Icons {
+        public var icons: Icons
+        public struct Icons {
             /// Corresponds to UIButton 'normalImage' property.
             public var normal: UIImage
             /// Corresponds to UIButton 'selectedImage' property.


### PR DESCRIPTION
In this PR added initializers  for ContentControlsViewController Props as an extension in a new file 

Refactored ContentControlsViewController and it doesn't contain nesting anymore. Instead of `Props.Player.Item.Controls`  we got `Props.Controls`. So, we don't have to describe all path to the type we want to create.
 
As a result we have a new way to initialise Props:
<details>
  <summary>Click to see original</summary>
<pre>
func props() -> Props {
    return Props.player(Props.Player{ player in
      player.playlist = nil
        player.item = .playable(Props.Controls { controls in
            controls.title = "Some title very very very very very very very very very long"
            controls.live.isHidden = true
            controls.seekbar = .init()
            controls.playbackAction = .pause(.nop)
            controls.camera = Props.Camera()
            controls.settings = .hidden
            controls.pictureInPictureControl = .unsupported
            controls.legible = .`internal`(nil)
            controls.title = ""
            controls.airplay = .enabled
        })
    })
}
</pre>
</details>

<details>
  <summary>Click to see new</summary>
<pre>
func props() -> Props {
    return Props.player(Props.Player(
        playlist: Props.Playlist(
            next: nil,
            prev: nil),
        item: .playable(Props.Controls(
            airplay: .enabled,
            audible: Props.MediaGroupControl(options: []),
            camera: Props.Camera(
                angles: Props.Angles(
                    horizontal: 0.0,
                    vertical: 0.0),
                moveTo: .nop),
            error: nil,
            legible: .external(
                external: .available(state: .active(text: "Somthing short")),
                control: Props.MediaGroupControl(options: [Props.Option(
                    name: "Option1",
                    selected: true,
                    select: .nop)])),
            live: Props.Live(
                isHidden: false,
                dotColor: nil),
            loading: false,
            pictureInPictureControl: .possible(.nop),
            playbackAction: .play(.nop),
            seekbar: Props.Seekbar(
                duration: 3600,
                currentTime: 1800,
                progress: 0.5,
                buffered: 0.7,
                seeker: Props.Seeker(
                    seekTo: .nop,
                    state: Props.State(
                        start: .nop,
                        update: .nop,
                        stop: .nop))),
            settings: .enabled(.nop),
            sideBarViewHidden: true,
            thumbnail: nil,
            title: "Long titel"))))
}
</pre>
</details>
 

