### PR TITLE
Removed all Carthage references in PlayerControls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,9 +46,6 @@ playground.xcworkspace
 # Carthage
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
-PlayerControls/Carthage/Checkouts
-
-PlayerControls/Carthage/Build
 
 # fastlane
 #

--- a/PlayerControls/Cartfile.private
+++ b/PlayerControls/Cartfile.private
@@ -1,2 +1,0 @@
-github "Quick/Quick" == 1.0.0
-github "Quick/Nimble" == 5.1.0

--- a/PlayerControls/Cartfile.resolved
+++ b/PlayerControls/Cartfile.resolved
@@ -1,2 +1,0 @@
-github "Quick/Nimble" "v5.1.0"
-github "Quick/Quick" "v1.0.0"

--- a/PlayerControls/PlayerControls.xcodeproj/project.pbxproj
+++ b/PlayerControls/PlayerControls.xcodeproj/project.pbxproj
@@ -622,10 +622,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEVELOPMENT_TEAM = 7FCMSU478D;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.aol.one.PlayerControlsTests;
@@ -638,10 +635,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEVELOPMENT_TEAM = 7FCMSU478D;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.aol.one.PlayerControlsTests;


### PR DESCRIPTION
Removed unnecessary files and records of Carthage, that have been located in PlayerControls. We used to have a Carthage to add **Quick** and **Nimble** frameworks in our project. As soon as it is gone, Cartfiles and a framework search path should be removed. Especially the last one, that caused a warning.