### PR TITLE
Fix default seeker bar time color

### DIFF
--- a/PlayerControls/sources/SeekerControlView.swift
+++ b/PlayerControls/sources/SeekerControlView.swift
@@ -46,6 +46,7 @@ final class SeekerControlView: UIView {
             
             currentTimeLabel = UILabel()
             currentTimeLabel.font = UIFont(name: "Helvetica", size: 10.0)
+            currentTimeLabel.textColor = tintColor
             
             addSubview(seekerFiller)
             addSubview(seekerBackground)


### PR DESCRIPTION
If tint color has not been changed, seeker bar time color remains black.
<img width="360" alt="screen_shot_2018-01-12_at_10 21 01_am_720" src="https://user-images.githubusercontent.com/14905005/34921877-717f1cf2-f990-11e7-99cc-6f9dc12ce0e4.png">
Actual: Seeker bar time color is black
Expected: Seeker bar time color as tint

[JIRA Issue](https://jira.ops.aol.com/browse/OMSDK-545)