### PR TITLE
Implemented Player Controls Animation

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0653692E2022317F00F65305 /* PropsDirector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0653692D2022317F00F65305 /* PropsDirector.swift */; };
 		DEE135021F0FD2F100C47354 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEE135011F0FD2F100C47354 /* AppDelegate.swift */; };
 		DEE135091F0FD2F100C47354 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DEE135081F0FD2F100C47354 /* Assets.xcassets */; };
 		DEE1350C1F0FD2F100C47354 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DEE1350A1F0FD2F100C47354 /* LaunchScreen.storyboard */; };
@@ -29,6 +30,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0653692D2022317F00F65305 /* PropsDirector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropsDirector.swift; sourceTree = "<group>"; };
 		DEE134FE1F0FD2F100C47354 /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DEE135011F0FD2F100C47354 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DEE135081F0FD2F100C47354 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -70,6 +72,7 @@
 			isa = PBXGroup;
 			children = (
 				DEE135011F0FD2F100C47354 /* AppDelegate.swift */,
+				0653692D2022317F00F65305 /* PropsDirector.swift */,
 				DEE135081F0FD2F100C47354 /* Assets.xcassets */,
 				DEE1350A1F0FD2F100C47354 /* LaunchScreen.storyboard */,
 				DEE1350D1F0FD2F100C47354 /* Info.plist */,
@@ -148,6 +151,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0653692E2022317F00F65305 /* PropsDirector.swift in Sources */,
 				DEE135021F0FD2F100C47354 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Demo/Demo/AppDelegate.swift
+++ b/Demo/Demo/AppDelegate.swift
@@ -42,7 +42,7 @@ func props() -> Props {
                         update: .nop,
                         stop: .nop))),
             settings: .enabled(.nop),
-            sideBarViewHidden: true,
+            sideBarViewHidden: false,
             thumbnail: nil,
             title: "Title"))))
 }
@@ -58,11 +58,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         vc.view.backgroundColor = .green
         vc.view.tintColor = .blue
         vc.props = props()
+        vc.sidebarProps = sideProps()
         let propsDirector = PropsDirector()
         
         propsDirector.buttonProps.append(contentsOf: propses())
         if #available(iOS 10.0, *) {
-            let timer = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: true) { (_) in
+            Timer.scheduledTimer(withTimeInterval: 1.5, repeats: true) { (_) in
                 vc.props = propsDirector.updateProps()
             }
         }
@@ -98,3 +99,51 @@ func propses() -> [ButtonsProps] {
     ]
 }
 
+func sideProps() -> [SideBarView.ButtonProps]{
+    
+    let shareIcons = SideBarView.ButtonProps.Icons(
+        normal: UIImage(named: "icon-share", in: Bundle(for: SideBarView.self), compatibleWith: nil)!,
+        selected: nil,
+        highlighted: UIImage(named: "icon-share-active", in: Bundle(for: SideBarView.self), compatibleWith: nil))
+    
+    let share = SideBarView.ButtonProps(
+        isEnabled: true,
+        isSelected: false,
+        icons: shareIcons,
+        handler: .nop)
+    
+    let addIcon = SideBarView.ButtonProps.Icons(
+        normal: UIImage(named: "icon-add", in: Bundle(for: SideBarView.self), compatibleWith: nil)!,
+        selected: nil,
+        highlighted: UIImage(named: "icon-add-active", in: Bundle(for: SideBarView.self), compatibleWith: nil))
+    
+    let add = SideBarView.ButtonProps(
+        isEnabled: true,
+        isSelected: false,
+        icons: addIcon,
+        handler: .nop)
+    
+    let favoriteIcon = SideBarView.ButtonProps.Icons(
+        normal: UIImage(named: "icon-fav", in: Bundle(for: SideBarView.self), compatibleWith: nil)!,
+        selected: nil,
+        highlighted: UIImage(named: "icon-fav-active", in: Bundle(for: SideBarView.self), compatibleWith: nil))
+    
+    let favorite = SideBarView.ButtonProps(
+        isEnabled: true,
+        isSelected: false,
+        icons: favoriteIcon,
+        handler: .nop)
+    
+    let laterIcon = SideBarView.ButtonProps.Icons(
+        normal: UIImage(named: "icon-later", in: Bundle(for: SideBarView.self), compatibleWith: nil)!,
+        selected: nil,
+        highlighted: UIImage(named: "icon-later-active", in: Bundle(for: SideBarView.self), compatibleWith: nil))
+    
+    let later = SideBarView.ButtonProps(
+        isEnabled: true,
+        isSelected: false,
+        icons: laterIcon,
+        handler: .nop)
+    
+    return [later, favorite, share, add]
+}

--- a/Demo/Demo/AppDelegate.swift
+++ b/Demo/Demo/AppDelegate.swift
@@ -58,12 +58,43 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         vc.view.backgroundColor = .green
         vc.view.tintColor = .blue
         vc.props = props()
+        let propsDirector = PropsDirector()
         
+        propsDirector.buttonProps.append(contentsOf: propses())
+        if #available(iOS 10.0, *) {
+            let timer = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: true) { (_) in
+                vc.props = propsDirector.updateProps()
+            }
+        }
+
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = vc
         window?.makeKeyAndVisible()
         
         return true
     }
+}
+
+func propses() -> [ButtonsProps] {
+    let seekerState = DefaultControlsViewController.Props.Seekbar(
+        duration: 3600,
+        currentTime: 1800,
+        progress: 0.5,
+        buffered: 0.7,
+        seeker: Props.Seeker(
+            seekTo: .nop,
+            state: Props.State(
+                start: .nop,
+                update: .nop,
+                stop: .nop)))
+    return [
+        ButtonsProps(settingsState: .enabled(.nop), airplayState: .enabled, pipState: .possible(.nop), seekerState: seekerState, titleState: "Title"),
+        ButtonsProps(settingsState: .hidden, airplayState: .hidden, pipState: .unsupported, seekerState: nil, titleState: ""),
+        ButtonsProps(settingsState: .enabled(.nop), airplayState: .enabled, pipState: .possible(.nop), seekerState: seekerState, titleState: "Title"),
+        ButtonsProps(settingsState: .enabled(.nop), airplayState: .enabled, pipState: .possible(.nop), seekerState: nil, titleState: "Title"),
+        ButtonsProps(settingsState: .enabled(.nop), airplayState: .enabled, pipState: .possible(.nop), seekerState: seekerState, titleState: "Title"),
+        ButtonsProps(settingsState: .hidden, airplayState: .hidden, pipState: .unsupported, seekerState: seekerState, titleState: ""),
+        ButtonsProps(settingsState: .enabled(.nop), airplayState: .enabled, pipState: .possible(.nop), seekerState: seekerState, titleState: "Title")
+    ]
 }
 

--- a/Demo/Demo/AppDelegate.swift
+++ b/Demo/Demo/AppDelegate.swift
@@ -1,7 +1,7 @@
 //  Copyright © 2018 Oath. All rights reserved.
 
 import UIKit
-@testable import PlayerControls
+import PlayerControls
 
 typealias Props = ContentControlsViewController.Props
 func props() -> Props {
@@ -44,7 +44,8 @@ func props() -> Props {
             settings: .enabled(.nop),
             sideBarViewHidden: false,
             thumbnail: nil,
-            title: "Title"))))
+            title: "Title")),
+        animationsEnabled: true))
 }
 
 @UIApplicationMain
@@ -60,7 +61,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         vc.props = props()
         vc.sidebarProps = sideProps()
         
-        vc.animationsEnabled = true
         vc.animationsDuration = 0.4
         
         let propsDirector = PropsDirector()
@@ -110,7 +110,8 @@ func seekerFadeAnimationScript() -> [DefaultControlsViewController.Props] {
 func noPlayerCase() -> DefaultControlsViewController.Props {
     return Props.player(Props.Player(
         playlist: nil,
-        item: Props.Item.nonplayable("Eror 404 player not found")))
+        item: Props.Item.nonplayable("Eror 404 player not found"),
+        animationsEnabled: true))
 }
 
 func everythingEmpty() -> DefaultControlsViewController.Props {
@@ -143,7 +144,8 @@ func everythingEmpty() -> DefaultControlsViewController.Props {
             settings: .hidden,
             sideBarViewHidden: false,
             thumbnail: nil,
-            title: ""))))
+            title: "")),
+        animationsEnabled: true))
 }
 
 func bottomViewAndSeekerVisible() -> DefaultControlsViewController.Props {
@@ -186,7 +188,8 @@ func bottomViewAndSeekerVisible() -> DefaultControlsViewController.Props {
             settings: .enabled(.nop),
             sideBarViewHidden: false,
             thumbnail: nil,
-            title: "Title"))))
+            title: "Title")),
+        animationsEnabled: true))
 }
 
 func onlySeekerVisible() -> DefaultControlsViewController.Props {
@@ -229,7 +232,8 @@ func onlySeekerVisible() -> DefaultControlsViewController.Props {
             settings: .hidden,
             sideBarViewHidden: false,
             thumbnail: nil,
-            title: ""))))
+            title: "")),
+        animationsEnabled: true))
 }
 
 func onlyBottomItemsViewVisible() -> DefaultControlsViewController.Props {
@@ -262,7 +266,8 @@ func onlyBottomItemsViewVisible() -> DefaultControlsViewController.Props {
             settings: .enabled(.nop),
             sideBarViewHidden: false,
             thumbnail: nil,
-            title: "Title"))))
+            title: "Title")),
+        animationsEnabled: true))
 }
 
 func sideProps() -> [SideBarView.ButtonProps]{

--- a/Demo/Demo/AppDelegate.swift
+++ b/Demo/Demo/AppDelegate.swift
@@ -44,7 +44,7 @@ func props() -> Props {
             settings: .enabled(.nop),
             sideBarViewHidden: true,
             thumbnail: nil,
-            title: "Long titel"))))
+            title: "Title"))))
 }
 
 @UIApplicationMain

--- a/Demo/Demo/PropsDirector.swift
+++ b/Demo/Demo/PropsDirector.swift
@@ -1,0 +1,94 @@
+//
+//  PropsDirector.swift
+//  Demo
+//
+//  Created by rtysiachnik on 1/31/18.
+//  Copyright © 2018 One by AOL : Publishers. All rights reserved.
+//
+
+import Foundation
+//  Copyright © 2018 One by AOL : Publishers. All rights reserved.
+
+import Foundation
+import PlayerControls
+
+struct ButtonsProps {
+    let settingsState: DefaultControlsViewController.Props.Settings
+    let airplayState: DefaultControlsViewController.Props.AirPlay
+    let pipState: DefaultControlsViewController.Props.PictureInPictureControl
+    let seekerState: DefaultControlsViewController.Props.Seekbar?
+    let titleState: String
+}
+
+class PropsDirector {
+    
+    var buttonProps: [ButtonsProps]
+    var index = 0
+    var endlessLoop: Bool = true
+    
+    
+    init() {
+        let seekerState = DefaultControlsViewController.Props.Seekbar(
+            duration: 3600,
+            currentTime: 1800,
+            progress: 0.5,
+            buffered: 0.7,
+            seeker: Props.Seeker(
+                seekTo: .nop,
+                state: Props.State(
+                    start: .nop,
+                    update: .nop,
+                    stop: .nop)))
+        buttonProps = [ButtonsProps(settingsState: .enabled(.nop), airplayState: .enabled, pipState: .possible(.nop), seekerState: seekerState, titleState: "Title")]
+    }
+    
+    func updateProps() -> DefaultControlsViewController.Props {
+        let props = setProps(buttonProps: buttonProps[index])
+        let maxIndex = buttonProps.count-1
+        if index == maxIndex { index = 0 } else { index += 1 }
+        return props
+    }
+    
+    func setProps(buttonProps: ButtonsProps) -> DefaultControlsViewController.Props {
+        return Props.player(Props.Player(
+            playlist: Props.Playlist(
+                next: .nop,
+                prev: .nop),
+            item: .playable(Props.Controls(
+                airplay: buttonProps.airplayState,
+                audible: Props.MediaGroupControl(options: []),
+                camera: Props.Camera(
+                    angles: Props.Angles(
+                        horizontal: 0.0,
+                        vertical: 0.0),
+                    moveTo: .nop),
+                error: nil,
+                legible: .external(
+                    external: .available(state: .active(text: "Somthing short")),
+                    control: Props.MediaGroupControl(options: [Props.Option(
+                        name: "Option1",
+                        selected: true,
+                        select: .nop)])),
+                live: Props.Live(
+                    isHidden: false,
+                    dotColor: nil),
+                loading: false,
+                pictureInPictureControl: buttonProps.pipState,
+                playbackAction: .play(.nop),
+                seekbar: Props.Seekbar(
+                    duration: 3600,
+                    currentTime: 1800,
+                    progress: 0.5,
+                    buffered: 0.7,
+                    seeker: Props.Seeker(
+                        seekTo: .nop,
+                        state: Props.State(
+                            start: .nop,
+                            update: .nop,
+                            stop: .nop))),
+                settings: buttonProps.settingsState,
+                sideBarViewHidden: false,
+                thumbnail: nil,
+                title: buttonProps.titleState))))
+    }
+}

--- a/Demo/Demo/PropsDirector.swift
+++ b/Demo/Demo/PropsDirector.swift
@@ -75,17 +75,7 @@ class PropsDirector {
                 loading: false,
                 pictureInPictureControl: buttonProps.pipState,
                 playbackAction: .play(.nop),
-                seekbar: Props.Seekbar(
-                    duration: 3600,
-                    currentTime: 1800,
-                    progress: 0.5,
-                    buffered: 0.7,
-                    seeker: Props.Seeker(
-                        seekTo: .nop,
-                        state: Props.State(
-                            start: .nop,
-                            update: .nop,
-                            stop: .nop))),
+                seekbar: buttonProps.seekerState,
                 settings: buttonProps.settingsState,
                 sideBarViewHidden: false,
                 thumbnail: nil,

--- a/Demo/Demo/PropsDirector.swift
+++ b/Demo/Demo/PropsDirector.swift
@@ -1,84 +1,23 @@
-//
-//  PropsDirector.swift
-//  Demo
-//
-//  Created by rtysiachnik on 1/31/18.
-//  Copyright © 2018 One by AOL : Publishers. All rights reserved.
-//
+//  Copyright © 2018 Oath. All rights reserved.
 
-import Foundation
-//  Copyright © 2018 One by AOL : Publishers. All rights reserved.
-
-import Foundation
 import PlayerControls
-
-struct ButtonsProps {
-    let settingsState: DefaultControlsViewController.Props.Settings
-    let airplayState: DefaultControlsViewController.Props.AirPlay
-    let pipState: DefaultControlsViewController.Props.PictureInPictureControl
-    let seekerState: DefaultControlsViewController.Props.Seekbar?
-    let titleState: String
-}
 
 class PropsDirector {
     
-    var buttonProps: [ButtonsProps]
-    var index = 0
-    var endlessLoop: Bool = true
+    var propsArray: [DefaultControlsViewController.Props] = []
+    ///Set value to false if you don't want endless applying of new props from array.
+    var endlessLoop = true
+
+    private var index = 0
     
-    
-    init() {
-        let seekerState = DefaultControlsViewController.Props.Seekbar(
-            duration: 3600,
-            currentTime: 1800,
-            progress: 0.5,
-            buffered: 0.7,
-            seeker: Props.Seeker(
-                seekTo: .nop,
-                state: Props.State(
-                    start: .nop,
-                    update: .nop,
-                    stop: .nop)))
-        buttonProps = [ButtonsProps(settingsState: .enabled(.nop), airplayState: .enabled, pipState: .possible(.nop), seekerState: seekerState, titleState: "Title")]
-    }
-    
-    func updateProps() -> DefaultControlsViewController.Props {
-        let props = setProps(buttonProps: buttonProps[index])
-        let maxIndex = buttonProps.count-1
-        if index == maxIndex { index = 0 } else { index += 1 }
+    func updateProps() -> DefaultControlsViewController.Props? {
+        guard !propsArray.isEmpty else { return nil }
+        let props = propsArray[index]
+        let maxIndex = propsArray.count-1
+        if index == maxIndex {
+            guard endlessLoop else { return nil }
+            index = 0
+        } else { index += 1 }
         return props
-    }
-    
-    func setProps(buttonProps: ButtonsProps) -> DefaultControlsViewController.Props {
-        return Props.player(Props.Player(
-            playlist: Props.Playlist(
-                next: .nop,
-                prev: .nop),
-            item: .playable(Props.Controls(
-                airplay: buttonProps.airplayState,
-                audible: Props.MediaGroupControl(options: []),
-                camera: Props.Camera(
-                    angles: Props.Angles(
-                        horizontal: 0.0,
-                        vertical: 0.0),
-                    moveTo: .nop),
-                error: nil,
-                legible: .external(
-                    external: .available(state: .active(text: "Somthing short")),
-                    control: Props.MediaGroupControl(options: [Props.Option(
-                        name: "Option1",
-                        selected: true,
-                        select: .nop)])),
-                live: Props.Live(
-                    isHidden: false,
-                    dotColor: nil),
-                loading: false,
-                pictureInPictureControl: buttonProps.pipState,
-                playbackAction: .play(.nop),
-                seekbar: buttonProps.seekerState,
-                settings: buttonProps.settingsState,
-                sideBarViewHidden: false,
-                thumbnail: nil,
-                title: buttonProps.titleState))))
     }
 }

--- a/PlayerControls/PlayerControls.xcodeproj/project.pbxproj
+++ b/PlayerControls/PlayerControls.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		06536931202320C100F65305 /* AnimationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06536930202320C100F65305 /* AnimationDelegate.swift */; };
 		0696270D1FD188A50098494A /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0696270C1FD188A50098494A /* Command.swift */; };
 		422017F41FE3D557002E4DE5 /* Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 422017F31FE3D557002E4DE5 /* Codable.swift */; };
 		427DA9131FFBA1E700698438 /* Defaultable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 427DA9121FFBA1E700698438 /* Defaultable.swift */; };
@@ -71,6 +72,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		06536930202320C100F65305 /* AnimationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationDelegate.swift; sourceTree = "<group>"; };
 		0696270C1FD188A50098494A /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		422017F31FE3D557002E4DE5 /* Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Codable.swift; sourceTree = "<group>"; };
 		427DA9121FFBA1E700698438 /* Defaultable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Defaultable.swift; sourceTree = "<group>"; };
@@ -133,6 +135,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0653692F2023207200F65305 /* animations */ = {
+			isa = PBXGroup;
+			children = (
+				06536930202320C100F65305 /* AnimationDelegate.swift */,
+			);
+			name = animations;
+			sourceTree = "<group>";
+		};
 		427DA9111FFBA12500698438 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
@@ -216,6 +226,7 @@
 			isa = PBXGroup;
 			children = (
 				DA070BAF1F8B76B9007F407D /* airplay */,
+				0653692F2023207200F65305 /* animations */,
 				50F471331F5958D300C35AEF /* settings */,
 				50582F931E65CD8D00B18908 /* seeker control view */,
 				50582F921E65CD8500B18908 /* side bar */,
@@ -458,6 +469,7 @@
 				50582F6E1E65C64B00B18908 /* ContentControlsViewController.swift in Sources */,
 				0696270D1FD188A50098494A /* Command.swift in Sources */,
 				50582F7E1E65C96100B18908 /* SeekGestureRecognizer.swift in Sources */,
+				06536931202320C100F65305 /* AnimationDelegate.swift in Sources */,
 				422017F41FE3D557002E4DE5 /* Codable.swift in Sources */,
 				50582F8C1E65CBE600B18908 /* Timer.swift in Sources */,
 				50F471591F5D763500C35AEF /* SettingHeaderView.swift in Sources */,

--- a/PlayerControls/resources/DefaultControlsViewController.xib
+++ b/PlayerControls/resources/DefaultControlsViewController.xib
@@ -13,8 +13,9 @@
             <connections>
                 <outlet property="airPlayView" destination="72o-zQ-Neb" id="H2B-hs-BSd"/>
                 <outlet property="airplayActiveLabel" destination="kPK-Sh-8jh" id="JaP-cu-vma"/>
-                <outlet property="airplayEdgeTrailingConstrains" destination="Vyl-vI-sAn" id="VCW-Qu-Qym"/>
-                <outlet property="airplayPipTrailingConstrains" destination="oHL-VL-d41" id="QIz-jM-MP2"/>
+                <outlet property="airplayEdgeTrailingConstrains" destination="QZF-YX-TTy" id="zAV-I0-xeo"/>
+                <outlet property="airplayPipTrailingConstrains" destination="Rmc-6f-Sga" id="7AY-u1-OE5"/>
+                <outlet property="bottomItemsView" destination="8y7-Mc-uq8" id="KFT-1o-P2P"/>
                 <outlet property="bottomSeekBarConstraint" destination="1rA-Ma-4OD" id="thy-r3-SLe"/>
                 <outlet property="cameraPanGestureRecognizer" destination="ZiF-3w-BsH" id="RtK-Tm-0VF"/>
                 <outlet property="ccTextLabel" destination="SEd-qf-YJr" id="RPz-r8-Q4U"/>
@@ -41,9 +42,9 @@
                 <outlet property="settingsButton" destination="Ddy-Jb-aVD" id="iE1-re-XF5"/>
                 <outlet property="shadowView" destination="m54-Yx-R7K" id="UrZ-Ce-oXW"/>
                 <outlet property="sideBarView" destination="Uc8-v7-96O" id="4eK-qd-dwS"/>
-                <outlet property="subtitlesAirplayTrailingConstrains" destination="W3f-YF-5Xe" id="kJT-VV-QKX"/>
-                <outlet property="subtitlesEdgeTrailingConstrains" destination="gLr-H3-hip" id="eQz-h0-b2M"/>
-                <outlet property="subtitlesPipTrailingConstrains" destination="PR9-OI-F49" id="2Eo-cw-l5K"/>
+                <outlet property="subtitlesAirplayTrailingConstrains" destination="fee-ei-GwZ" id="zIB-Cp-aD9"/>
+                <outlet property="subtitlesEdgeTrailingConstrains" destination="geE-p0-gZ0" id="mPR-gm-pTn"/>
+                <outlet property="subtitlesPipTrailingConstrains" destination="6mX-Nf-m9k" id="Tuf-6d-L2G"/>
                 <outlet property="thumbnailImageView" destination="NKq-bU-tvG" id="6hP-L5-BvJ"/>
                 <outlet property="videoTitleLabel" destination="98K-SA-Pdv" id="ObX-ZK-rlC"/>
                 <outlet property="view" destination="rFH-6N-3gH" id="KAd-hV-jYD"/>
@@ -99,14 +100,6 @@ Subtitles</string>
                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="compas-direction" translatesAutoresizingMaskIntoConstraints="NO" id="6eW-2a-aeL">
                             <rect key="frame" x="10" y="20" width="30" height="30"/>
                         </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="98K-SA-Pdv">
-                            <rect key="frame" x="15" y="318" width="35" height="43"/>
-                            <string key="text">Title
-Title</string>
-                            <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                            <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <nil key="highlightedColor"/>
-                        </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wVE-Q8-zOG">
                             <rect key="frame" x="286.5" y="140.5" width="95" height="95"/>
                             <accessibility key="accessibilityConfiguration" label="Replay content video"/>
@@ -176,38 +169,6 @@ Title</string>
                                 <action selector="seekBackButtonTouched" destination="-1" eventType="touchUpInside" id="xzh-Qs-Gdg"/>
                             </connections>
                         </button>
-                        <button hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tGV-rG-prj" userLabel="PiP">
-                            <rect key="frame" x="580" y="322" width="32" height="32"/>
-                            <accessibility key="accessibilityConfiguration" label="Picture in picture"/>
-                            <state key="normal" image="icon-pip"/>
-                            <state key="highlighted" image="icon-pip-active"/>
-                            <connections>
-                                <action selector="pipButtonTouched" destination="-1" eventType="touchUpInside" id="qcy-N3-td4"/>
-                            </connections>
-                        </button>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ddy-Jb-aVD">
-                            <rect key="frame" x="486" y="322" width="32" height="32"/>
-                            <accessibility key="accessibilityConfiguration" label="Settings"/>
-                            <state key="normal" image="icon-sub">
-                                <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                            </state>
-                            <state key="highlighted" image="icon-sub-active"/>
-                            <connections>
-                                <action selector="settingsButtonTouched" destination="-1" eventType="touchUpInside" id="gEB-3k-nGv"/>
-                            </connections>
-                        </button>
-                        <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="72o-zQ-Neb" customClass="AirPlayView" customModule="PlayerControls" customModuleProvider="target">
-                            <rect key="frame" x="533" y="322" width="32" height="32"/>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                            <accessibility key="accessibilityConfiguration" label="AirPlay">
-                                <accessibilityTraits key="traits" button="YES"/>
-                                <bool key="isElement" value="YES"/>
-                            </accessibility>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="32" id="kVT-H7-Wgy"/>
-                                <constraint firstAttribute="width" constant="32" id="oXo-18-PP0"/>
-                            </constraints>
-                        </view>
                         <view contentMode="scaleToFill" placeholderIntrinsicWidth="30" placeholderIntrinsicHeight="infinite" translatesAutoresizingMaskIntoConstraints="NO" id="Uc8-v7-96O" customClass="SideBarView" customModule="PlayerControls" customModuleProvider="target">
                             <rect key="frame" x="637" y="0.0" width="30" height="281.5"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -235,6 +196,74 @@ Title</string>
                             <color key="textColor" red="0.81568627450980391" green="0.81568627450980391" blue="0.81568627450980391" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8y7-Mc-uq8" userLabel="Bottom Items View">
+                            <rect key="frame" x="0.0" y="322" width="667" height="53"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="98K-SA-Pdv">
+                                    <rect key="frame" x="15" y="-4" width="35" height="43"/>
+                                    <string key="text">Title
+Title</string>
+                                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ddy-Jb-aVD">
+                                    <rect key="frame" x="486" y="0.0" width="32" height="32"/>
+                                    <accessibility key="accessibilityConfiguration" label="Settings"/>
+                                    <state key="normal" image="icon-sub">
+                                        <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    </state>
+                                    <state key="highlighted" image="icon-sub-active"/>
+                                    <connections>
+                                        <action selector="settingsButtonTouched" destination="-1" eventType="touchUpInside" id="gEB-3k-nGv"/>
+                                    </connections>
+                                </button>
+                                <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="72o-zQ-Neb" customClass="AirPlayView" customModule="PlayerControls" customModuleProvider="target">
+                                    <rect key="frame" x="533" y="0.0" width="32" height="32"/>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                    <accessibility key="accessibilityConfiguration" label="AirPlay">
+                                        <accessibilityTraits key="traits" button="YES"/>
+                                        <bool key="isElement" value="YES"/>
+                                    </accessibility>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="32" id="kVT-H7-Wgy"/>
+                                        <constraint firstAttribute="width" constant="32" id="oXo-18-PP0"/>
+                                    </constraints>
+                                </view>
+                                <button hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tGV-rG-prj" userLabel="PiP">
+                                    <rect key="frame" x="580" y="0.0" width="32" height="32"/>
+                                    <accessibility key="accessibilityConfiguration" label="Picture in picture"/>
+                                    <state key="normal" image="icon-pip"/>
+                                    <state key="highlighted" image="icon-pip-active"/>
+                                    <connections>
+                                        <action selector="pipButtonTouched" destination="-1" eventType="touchUpInside" id="qcy-N3-td4"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            <constraints>
+                                <constraint firstItem="tGV-rG-prj" firstAttribute="leading" secondItem="Ddy-Jb-aVD" secondAttribute="trailing" constant="15" id="6mX-Nf-m9k"/>
+                                <constraint firstItem="Ddy-Jb-aVD" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="98K-SA-Pdv" secondAttribute="trailing" constant="15" id="DLB-gl-3Xi"/>
+                                <constraint firstAttribute="bottom" secondItem="Ddy-Jb-aVD" secondAttribute="bottom" constant="21" id="EPS-cV-9xJ"/>
+                                <constraint firstItem="98K-SA-Pdv" firstAttribute="top" secondItem="Ddy-Jb-aVD" secondAttribute="top" constant="-4" id="EYR-xh-sKU"/>
+                                <constraint firstItem="tGV-rG-prj" firstAttribute="centerY" secondItem="Ddy-Jb-aVD" secondAttribute="centerY" id="FDd-JY-pRI"/>
+                                <constraint firstItem="72o-zQ-Neb" firstAttribute="centerY" secondItem="Ddy-Jb-aVD" secondAttribute="centerY" id="OHp-BX-8v4"/>
+                                <constraint firstAttribute="trailing" secondItem="72o-zQ-Neb" secondAttribute="trailing" constant="55" id="QZF-YX-TTy"/>
+                                <constraint firstItem="tGV-rG-prj" firstAttribute="leading" secondItem="72o-zQ-Neb" secondAttribute="trailing" constant="15" id="Rmc-6f-Sga"/>
+                                <constraint firstAttribute="trailing" secondItem="tGV-rG-prj" secondAttribute="trailing" constant="55" id="YjR-Vc-LlO"/>
+                                <constraint firstItem="72o-zQ-Neb" firstAttribute="leading" secondItem="Ddy-Jb-aVD" secondAttribute="trailing" constant="15" id="fee-ei-GwZ"/>
+                                <constraint firstAttribute="trailing" secondItem="Ddy-Jb-aVD" secondAttribute="trailing" constant="55" id="geE-p0-gZ0"/>
+                                <constraint firstAttribute="height" constant="53" id="grI-1x-tIl"/>
+                                <constraint firstItem="98K-SA-Pdv" firstAttribute="leading" secondItem="8y7-Mc-uq8" secondAttribute="leading" constant="15" id="r0o-DX-aP2"/>
+                            </constraints>
+                            <variation key="default">
+                                <mask key="constraints">
+                                    <exclude reference="geE-p0-gZ0"/>
+                                    <exclude reference="QZF-YX-TTy"/>
+                                    <exclude reference="6mX-Nf-m9k"/>
+                                </mask>
+                            </variation>
+                        </view>
                     </subviews>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     <gestureRecognizers/>
@@ -249,30 +278,21 @@ Title</string>
                         <constraint firstItem="KeK-cX-xXB" firstAttribute="centerY" secondItem="U8A-X2-cyf" secondAttribute="centerY" id="Bug-m8-Fqm"/>
                         <constraint firstItem="Uc8-v7-96O" firstAttribute="top" secondItem="fi9-sW-1VX" secondAttribute="top" id="DWa-IY-lCj"/>
                         <constraint firstItem="fAO-vH-cgi" firstAttribute="top" secondItem="Uc8-v7-96O" secondAttribute="bottom" constant="-23" id="EEn-7U-jDF"/>
-                        <constraint firstAttribute="trailing" secondItem="tGV-rG-prj" secondAttribute="trailing" constant="55" id="F29-fV-Pgy"/>
                         <constraint firstItem="ida-wI-kAP" firstAttribute="centerY" secondItem="djN-u7-nkt" secondAttribute="centerY" id="F2z-D3-yET"/>
-                        <constraint firstItem="Ddy-Jb-aVD" firstAttribute="centerY" secondItem="tGV-rG-prj" secondAttribute="centerY" id="FM3-YM-YML"/>
                         <constraint firstItem="73i-r1-qKj" firstAttribute="centerY" secondItem="cNh-R2-LdG" secondAttribute="centerY" id="HWP-bD-q7I"/>
                         <constraint firstItem="6eW-2a-aeL" firstAttribute="centerX" secondItem="l0O-oR-0Rg" secondAttribute="centerX" id="HlO-Pl-IWR"/>
                         <constraint firstItem="l0O-oR-0Rg" firstAttribute="leading" secondItem="fi9-sW-1VX" secondAttribute="leading" constant="10" id="JdE-Uf-1u0"/>
                         <constraint firstItem="cNh-R2-LdG" firstAttribute="centerY" secondItem="U8A-X2-cyf" secondAttribute="centerY" id="MDB-2d-aWk"/>
                         <constraint firstItem="fAO-vH-cgi" firstAttribute="leading" secondItem="fi9-sW-1VX" secondAttribute="leading" id="OYY-c7-642"/>
-                        <constraint firstItem="tGV-rG-prj" firstAttribute="leading" secondItem="Ddy-Jb-aVD" secondAttribute="trailing" constant="15" id="PR9-OI-F49"/>
                         <constraint firstItem="m54-Yx-R7K" firstAttribute="centerY" secondItem="U8A-X2-cyf" secondAttribute="centerY" id="PrJ-1T-4v4"/>
                         <constraint firstAttribute="trailing" secondItem="Uc8-v7-96O" secondAttribute="trailing" constant="0.5" id="Pzo-A9-BH0"/>
                         <constraint firstAttribute="trailing" secondItem="fAO-vH-cgi" secondAttribute="trailing" id="SFG-A0-7XF"/>
-                        <constraint firstItem="Ddy-Jb-aVD" firstAttribute="top" secondItem="98K-SA-Pdv" secondAttribute="top" constant="4" id="T2T-Lh-XIZ"/>
-                        <constraint firstAttribute="bottom" secondItem="Ddy-Jb-aVD" secondAttribute="bottom" constant="21" id="Uxr-4B-Jz5"/>
-                        <constraint firstAttribute="trailing" secondItem="72o-zQ-Neb" secondAttribute="trailing" constant="55" id="Vyl-vI-sAn">
-                            <variation key="heightClass=compact-widthClass=regular" constant="55"/>
-                        </constraint>
-                        <constraint firstItem="72o-zQ-Neb" firstAttribute="leading" secondItem="Ddy-Jb-aVD" secondAttribute="trailing" constant="15" id="W3f-YF-5Xe"/>
-                        <constraint firstAttribute="trailing" secondItem="tGV-rG-prj" secondAttribute="trailing" constant="55" id="Wfq-Ma-a8M"/>
-                        <constraint firstItem="Ddy-Jb-aVD" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="98K-SA-Pdv" secondAttribute="trailing" constant="15" id="bbS-tP-ljB"/>
+                        <constraint firstItem="8y7-Mc-uq8" firstAttribute="leading" secondItem="fi9-sW-1VX" secondAttribute="leading" id="Svu-2t-QSO"/>
+                        <constraint firstAttribute="bottom" secondItem="8y7-Mc-uq8" secondAttribute="bottom" id="bIH-ZD-ij1"/>
+                        <constraint firstItem="8y7-Mc-uq8" firstAttribute="top" secondItem="fAO-vH-cgi" secondAttribute="bottom" constant="6.5" id="dM6-vN-wjR"/>
                         <constraint firstAttribute="trailing" secondItem="Im0-Vw-2gZ" secondAttribute="trailing" constant="17" id="eTt-xT-Hay"/>
                         <constraint firstItem="m54-Yx-R7K" firstAttribute="top" secondItem="fi9-sW-1VX" secondAttribute="top" id="fv1-Ls-gs3"/>
                         <constraint firstItem="ikX-6f-FSq" firstAttribute="centerY" secondItem="U8A-X2-cyf" secondAttribute="centerY" id="g57-te-Fqp"/>
-                        <constraint firstAttribute="trailing" secondItem="Ddy-Jb-aVD" secondAttribute="trailing" constant="55" id="gLr-H3-hip"/>
                         <constraint firstItem="ikX-6f-FSq" firstAttribute="centerX" secondItem="U8A-X2-cyf" secondAttribute="centerX" id="hHz-DU-eUK"/>
                         <constraint firstItem="m54-Yx-R7K" firstAttribute="leading" secondItem="fi9-sW-1VX" secondAttribute="leading" id="iTM-by-B9G"/>
                         <constraint firstItem="Im0-Vw-2gZ" firstAttribute="top" secondItem="fAO-vH-cgi" secondAttribute="bottom" constant="-3" id="if2-R8-sVs">
@@ -283,7 +303,7 @@ Title</string>
                             <variation key="widthClass=regular" constant="20"/>
                         </constraint>
                         <constraint firstItem="l0O-oR-0Rg" firstAttribute="top" secondItem="fi9-sW-1VX" secondAttribute="top" constant="20" id="mIu-gb-Ffc"/>
-                        <constraint firstItem="tGV-rG-prj" firstAttribute="leading" secondItem="72o-zQ-Neb" secondAttribute="trailing" constant="15" id="oHL-VL-d41"/>
+                        <constraint firstAttribute="trailing" secondItem="8y7-Mc-uq8" secondAttribute="trailing" id="nNG-9w-zjf"/>
                         <constraint firstItem="djN-u7-nkt" firstAttribute="leading" secondItem="U8A-X2-cyf" secondAttribute="trailing" constant="6" id="pG8-cM-rpN"/>
                         <constraint firstItem="fAO-vH-cgi" firstAttribute="top" relation="greaterThanOrEqual" secondItem="U8A-X2-cyf" secondAttribute="bottom" constant="-5" id="put-WR-Szd">
                             <variation key="widthClass=compact" constant="-5"/>
@@ -297,8 +317,6 @@ Title</string>
                             <variation key="widthClass=regular" constant="20"/>
                         </constraint>
                         <constraint firstItem="6eW-2a-aeL" firstAttribute="centerY" secondItem="l0O-oR-0Rg" secondAttribute="centerY" id="v65-Bl-Csa"/>
-                        <constraint firstItem="98K-SA-Pdv" firstAttribute="leading" secondItem="fi9-sW-1VX" secondAttribute="leading" constant="15" id="w88-zY-fND"/>
-                        <constraint firstItem="Ddy-Jb-aVD" firstAttribute="centerY" secondItem="72o-zQ-Neb" secondAttribute="centerY" id="wBh-pZ-zXo"/>
                         <constraint firstItem="wVE-Q8-zOG" firstAttribute="centerY" secondItem="U8A-X2-cyf" secondAttribute="centerY" id="xAL-Mr-aiA"/>
                         <constraint firstItem="U8A-X2-cyf" firstAttribute="centerX" secondItem="fi9-sW-1VX" secondAttribute="centerX" id="y9t-79-v13"/>
                         <constraint firstItem="wVE-Q8-zOG" firstAttribute="centerX" secondItem="U8A-X2-cyf" secondAttribute="centerX" id="zsd-wr-B4P"/>
@@ -316,31 +334,28 @@ Title</string>
                             <exclude reference="fAO-vH-cgi"/>
                         </mask>
                         <mask key="constraints">
-                            <exclude reference="HWP-bD-q7I"/>
                             <exclude reference="EEn-7U-jDF"/>
                             <exclude reference="OYY-c7-642"/>
                             <exclude reference="SFG-A0-7XF"/>
                             <exclude reference="put-WR-Szd"/>
+                            <exclude reference="HWP-bD-q7I"/>
                             <exclude reference="MDB-2d-aWk"/>
                             <exclude reference="sZA-Tb-Cie"/>
-                            <exclude reference="g57-te-Fqp"/>
-                            <exclude reference="hHz-DU-eUK"/>
                             <exclude reference="2EN-h1-ldw"/>
                             <exclude reference="Bug-m8-Fqm"/>
                             <exclude reference="1RA-jh-Xfd"/>
                             <exclude reference="sPA-I1-YzI"/>
                             <exclude reference="y9t-79-v13"/>
+                            <exclude reference="g57-te-Fqp"/>
+                            <exclude reference="hHz-DU-eUK"/>
                             <exclude reference="xAL-Mr-aiA"/>
                             <exclude reference="zsd-wr-B4P"/>
                             <exclude reference="79p-mr-0NO"/>
                             <exclude reference="pG8-cM-rpN"/>
                             <exclude reference="F2z-D3-yET"/>
                             <exclude reference="iww-Ws-dSP"/>
-                            <exclude reference="gLr-H3-hip"/>
-                            <exclude reference="Vyl-vI-sAn"/>
                             <exclude reference="DWa-IY-lCj"/>
                             <exclude reference="Pzo-A9-BH0"/>
-                            <exclude reference="PR9-OI-F49"/>
                             <exclude reference="eTt-xT-Hay"/>
                         </mask>
                     </variation>
@@ -357,20 +372,20 @@ Title</string>
                             <include reference="fAO-vH-cgi"/>
                         </mask>
                         <mask key="constraints">
-                            <include reference="HWP-bD-q7I"/>
                             <include reference="EEn-7U-jDF"/>
                             <include reference="OYY-c7-642"/>
                             <include reference="SFG-A0-7XF"/>
                             <include reference="put-WR-Szd"/>
+                            <include reference="HWP-bD-q7I"/>
                             <include reference="MDB-2d-aWk"/>
                             <include reference="sZA-Tb-Cie"/>
-                            <include reference="g57-te-Fqp"/>
-                            <include reference="hHz-DU-eUK"/>
                             <include reference="2EN-h1-ldw"/>
                             <include reference="Bug-m8-Fqm"/>
                             <include reference="1RA-jh-Xfd"/>
                             <include reference="sPA-I1-YzI"/>
                             <include reference="y9t-79-v13"/>
+                            <include reference="g57-te-Fqp"/>
+                            <include reference="hHz-DU-eUK"/>
                             <include reference="xAL-Mr-aiA"/>
                             <include reference="zsd-wr-B4P"/>
                             <include reference="79p-mr-0NO"/>
@@ -395,20 +410,20 @@ Title</string>
                             <include reference="fAO-vH-cgi"/>
                         </mask>
                         <mask key="constraints">
-                            <include reference="HWP-bD-q7I"/>
                             <include reference="EEn-7U-jDF"/>
                             <include reference="OYY-c7-642"/>
                             <include reference="SFG-A0-7XF"/>
                             <include reference="put-WR-Szd"/>
+                            <include reference="HWP-bD-q7I"/>
                             <include reference="MDB-2d-aWk"/>
                             <include reference="sZA-Tb-Cie"/>
-                            <include reference="g57-te-Fqp"/>
-                            <include reference="hHz-DU-eUK"/>
                             <include reference="2EN-h1-ldw"/>
                             <include reference="Bug-m8-Fqm"/>
                             <include reference="1RA-jh-Xfd"/>
                             <include reference="sPA-I1-YzI"/>
                             <include reference="y9t-79-v13"/>
+                            <include reference="g57-te-Fqp"/>
+                            <include reference="hHz-DU-eUK"/>
                             <include reference="xAL-Mr-aiA"/>
                             <include reference="zsd-wr-B4P"/>
                             <include reference="79p-mr-0NO"/>
@@ -507,7 +522,7 @@ Title</string>
                 <outletCollection property="gestureRecognizers" destination="ydI-nT-cAb" appends="YES" id="w9x-Nr-aVL"/>
                 <outletCollection property="gestureRecognizers" destination="ZiF-3w-BsH" appends="YES" id="gz4-El-Rax"/>
             </connections>
-            <point key="canvasLocation" x="34" y="53"/>
+            <point key="canvasLocation" x="33.5" y="52.5"/>
         </view>
         <panGestureRecognizer minimumNumberOfTouches="1" maximumNumberOfTouches="1" id="ZiF-3w-BsH">
             <connections>

--- a/PlayerControls/resources/DefaultControlsViewController.xib
+++ b/PlayerControls/resources/DefaultControlsViewController.xib
@@ -242,7 +242,7 @@ Title</string>
                                     </connections>
                                 </button>
                             </subviews>
-                            <color key="backgroundColor" red="0.63457241490000005" green="0.84397296349999995" blue="0.91185637949999998" alpha="0.20843419894366197" colorSpace="custom" customColorSpace="sRGB"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                             <constraints>
                                 <constraint firstItem="tGV-rG-prj" firstAttribute="leading" secondItem="Ddy-Jb-aVD" secondAttribute="trailing" constant="15" id="6mX-Nf-m9k"/>
                                 <constraint firstItem="Ddy-Jb-aVD" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="98K-SA-Pdv" secondAttribute="trailing" constant="15" id="DLB-gl-3Xi"/>
@@ -335,24 +335,24 @@ Title</string>
                             <exclude reference="fAO-vH-cgi"/>
                         </mask>
                         <mask key="constraints">
+                            <exclude reference="HWP-bD-q7I"/>
                             <exclude reference="7au-pl-AdU"/>
                             <exclude reference="EEn-7U-jDF"/>
                             <exclude reference="OYY-c7-642"/>
                             <exclude reference="SFG-A0-7XF"/>
                             <exclude reference="put-WR-Szd"/>
-                            <exclude reference="HWP-bD-q7I"/>
                             <exclude reference="MDB-2d-aWk"/>
                             <exclude reference="sZA-Tb-Cie"/>
+                            <exclude reference="g57-te-Fqp"/>
+                            <exclude reference="hHz-DU-eUK"/>
+                            <exclude reference="bIH-ZD-ij1"/>
                             <exclude reference="2EN-h1-ldw"/>
                             <exclude reference="Bug-m8-Fqm"/>
                             <exclude reference="1RA-jh-Xfd"/>
                             <exclude reference="sPA-I1-YzI"/>
                             <exclude reference="y9t-79-v13"/>
-                            <exclude reference="g57-te-Fqp"/>
-                            <exclude reference="hHz-DU-eUK"/>
                             <exclude reference="xAL-Mr-aiA"/>
                             <exclude reference="zsd-wr-B4P"/>
-                            <exclude reference="bIH-ZD-ij1"/>
                             <exclude reference="79p-mr-0NO"/>
                             <exclude reference="pG8-cM-rpN"/>
                             <exclude reference="F2z-D3-yET"/>
@@ -375,20 +375,20 @@ Title</string>
                             <include reference="fAO-vH-cgi"/>
                         </mask>
                         <mask key="constraints">
+                            <include reference="HWP-bD-q7I"/>
                             <include reference="EEn-7U-jDF"/>
                             <include reference="OYY-c7-642"/>
                             <include reference="SFG-A0-7XF"/>
                             <include reference="put-WR-Szd"/>
-                            <include reference="HWP-bD-q7I"/>
                             <include reference="MDB-2d-aWk"/>
                             <include reference="sZA-Tb-Cie"/>
+                            <include reference="g57-te-Fqp"/>
+                            <include reference="hHz-DU-eUK"/>
                             <include reference="2EN-h1-ldw"/>
                             <include reference="Bug-m8-Fqm"/>
                             <include reference="1RA-jh-Xfd"/>
                             <include reference="sPA-I1-YzI"/>
                             <include reference="y9t-79-v13"/>
-                            <include reference="g57-te-Fqp"/>
-                            <include reference="hHz-DU-eUK"/>
                             <include reference="xAL-Mr-aiA"/>
                             <include reference="zsd-wr-B4P"/>
                             <include reference="79p-mr-0NO"/>
@@ -413,20 +413,20 @@ Title</string>
                             <include reference="fAO-vH-cgi"/>
                         </mask>
                         <mask key="constraints">
+                            <include reference="HWP-bD-q7I"/>
                             <include reference="EEn-7U-jDF"/>
                             <include reference="OYY-c7-642"/>
                             <include reference="SFG-A0-7XF"/>
                             <include reference="put-WR-Szd"/>
-                            <include reference="HWP-bD-q7I"/>
                             <include reference="MDB-2d-aWk"/>
                             <include reference="sZA-Tb-Cie"/>
+                            <include reference="g57-te-Fqp"/>
+                            <include reference="hHz-DU-eUK"/>
                             <include reference="2EN-h1-ldw"/>
                             <include reference="Bug-m8-Fqm"/>
                             <include reference="1RA-jh-Xfd"/>
                             <include reference="sPA-I1-YzI"/>
                             <include reference="y9t-79-v13"/>
-                            <include reference="g57-te-Fqp"/>
-                            <include reference="hHz-DU-eUK"/>
                             <include reference="xAL-Mr-aiA"/>
                             <include reference="zsd-wr-B4P"/>
                             <include reference="79p-mr-0NO"/>

--- a/PlayerControls/resources/DefaultControlsViewController.xib
+++ b/PlayerControls/resources/DefaultControlsViewController.xib
@@ -43,7 +43,11 @@
                 <outlet property="seekerView" destination="fAO-vH-cgi" id="mC9-GB-wqD"/>
                 <outlet property="settingsButton" destination="Ddy-Jb-aVD" id="iE1-re-XF5"/>
                 <outlet property="shadowView" destination="m54-Yx-R7K" id="UrZ-Ce-oXW"/>
+                <outlet property="sideBarBottomConstraint" destination="coa-PV-KiP" id="aw7-zz-bPT"/>
+                <outlet property="sideBarInvisibleConstraint" destination="Yy9-r3-97c" id="TgC-vy-QtR"/>
+                <outlet property="sideBarSeekerConstraint" destination="EEn-7U-jDF" id="m3S-Fa-6x6"/>
                 <outlet property="sideBarView" destination="Uc8-v7-96O" id="4eK-qd-dwS"/>
+                <outlet property="sideBarVisibleConstraint" destination="Pzo-A9-BH0" id="dIe-Ja-5aF"/>
                 <outlet property="subtitlesAirplayTrailingConstrains" destination="fee-ei-GwZ" id="zIB-Cp-aD9"/>
                 <outlet property="subtitlesEdgeTrailingConstrains" destination="geE-p0-gZ0" id="mPR-gm-pTn"/>
                 <outlet property="subtitlesPipTrailingConstrains" destination="6mX-Nf-m9k" id="Tuf-6d-L2G"/>
@@ -172,11 +176,11 @@ Subtitles</string>
                             </connections>
                         </button>
                         <view contentMode="scaleToFill" placeholderIntrinsicWidth="30" placeholderIntrinsicHeight="infinite" translatesAutoresizingMaskIntoConstraints="NO" id="Uc8-v7-96O" customClass="SideBarView" customModule="PlayerControls" customModuleProvider="target">
-                            <rect key="frame" x="637" y="0.0" width="30" height="281"/>
+                            <rect key="frame" x="636.5" y="0.0" width="30" height="287.5"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
                         <view hidden="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="57" translatesAutoresizingMaskIntoConstraints="NO" id="fAO-vH-cgi" customClass="SeekerControlView" customModule="PlayerControls" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="258" width="667" height="57"/>
+                            <rect key="frame" x="0.0" y="264.5" width="667" height="57"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <accessibility key="accessibilityConfiguration">
                                 <accessibilityTraits key="traits" adjustable="YES"/>
@@ -192,7 +196,7 @@ Subtitles</string>
                             </userDefinedRuntimeAttributes>
                         </view>
                         <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Im0-Vw-2gZ">
-                            <rect key="frame" x="618" y="312" width="32" height="14"/>
+                            <rect key="frame" x="618" y="318.5" width="32" height="14"/>
                             <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                             <color key="textColor" red="0.81568627450980391" green="0.81568627450980391" blue="0.81568627450980391" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -288,8 +292,9 @@ Title</string>
                         <constraint firstAttribute="trailing" secondItem="Uc8-v7-96O" secondAttribute="trailing" constant="0.5" id="Pzo-A9-BH0"/>
                         <constraint firstAttribute="trailing" secondItem="fAO-vH-cgi" secondAttribute="trailing" id="SFG-A0-7XF"/>
                         <constraint firstItem="8y7-Mc-uq8" firstAttribute="leading" secondItem="fi9-sW-1VX" secondAttribute="leading" id="Svu-2t-QSO"/>
+                        <constraint firstAttribute="trailing" secondItem="Uc8-v7-96O" secondAttribute="trailing" constant="-31" id="Yy9-r3-97c"/>
                         <constraint firstAttribute="bottom" secondItem="8y7-Mc-uq8" secondAttribute="top" id="bIH-ZD-ij1"/>
-                        <constraint firstItem="8y7-Mc-uq8" firstAttribute="top" secondItem="fAO-vH-cgi" secondAttribute="bottom" constant="6.5" id="dM6-vN-wjR"/>
+                        <constraint firstItem="8y7-Mc-uq8" firstAttribute="top" secondItem="fAO-vH-cgi" secondAttribute="bottom" constant="0.14999999999999999" id="dM6-vN-wjR"/>
                         <constraint firstAttribute="trailing" secondItem="Im0-Vw-2gZ" secondAttribute="trailing" constant="17" id="eTt-xT-Hay"/>
                         <constraint firstItem="m54-Yx-R7K" firstAttribute="top" secondItem="fi9-sW-1VX" secondAttribute="top" id="fv1-Ls-gs3"/>
                         <constraint firstItem="ikX-6f-FSq" firstAttribute="centerY" secondItem="U8A-X2-cyf" secondAttribute="centerY" id="g57-te-Fqp"/>
@@ -335,30 +340,31 @@ Title</string>
                             <exclude reference="fAO-vH-cgi"/>
                         </mask>
                         <mask key="constraints">
-                            <exclude reference="HWP-bD-q7I"/>
                             <exclude reference="7au-pl-AdU"/>
                             <exclude reference="EEn-7U-jDF"/>
                             <exclude reference="OYY-c7-642"/>
                             <exclude reference="SFG-A0-7XF"/>
                             <exclude reference="put-WR-Szd"/>
+                            <exclude reference="HWP-bD-q7I"/>
                             <exclude reference="MDB-2d-aWk"/>
                             <exclude reference="sZA-Tb-Cie"/>
-                            <exclude reference="g57-te-Fqp"/>
-                            <exclude reference="hHz-DU-eUK"/>
-                            <exclude reference="bIH-ZD-ij1"/>
                             <exclude reference="2EN-h1-ldw"/>
                             <exclude reference="Bug-m8-Fqm"/>
                             <exclude reference="1RA-jh-Xfd"/>
                             <exclude reference="sPA-I1-YzI"/>
                             <exclude reference="y9t-79-v13"/>
+                            <exclude reference="g57-te-Fqp"/>
+                            <exclude reference="hHz-DU-eUK"/>
                             <exclude reference="xAL-Mr-aiA"/>
                             <exclude reference="zsd-wr-B4P"/>
+                            <exclude reference="bIH-ZD-ij1"/>
                             <exclude reference="79p-mr-0NO"/>
                             <exclude reference="pG8-cM-rpN"/>
                             <exclude reference="F2z-D3-yET"/>
                             <exclude reference="iww-Ws-dSP"/>
                             <exclude reference="DWa-IY-lCj"/>
                             <exclude reference="Pzo-A9-BH0"/>
+                            <exclude reference="Yy9-r3-97c"/>
                             <exclude reference="eTt-xT-Hay"/>
                         </mask>
                     </variation>
@@ -375,20 +381,20 @@ Title</string>
                             <include reference="fAO-vH-cgi"/>
                         </mask>
                         <mask key="constraints">
-                            <include reference="HWP-bD-q7I"/>
                             <include reference="EEn-7U-jDF"/>
                             <include reference="OYY-c7-642"/>
                             <include reference="SFG-A0-7XF"/>
                             <include reference="put-WR-Szd"/>
+                            <include reference="HWP-bD-q7I"/>
                             <include reference="MDB-2d-aWk"/>
                             <include reference="sZA-Tb-Cie"/>
-                            <include reference="g57-te-Fqp"/>
-                            <include reference="hHz-DU-eUK"/>
                             <include reference="2EN-h1-ldw"/>
                             <include reference="Bug-m8-Fqm"/>
                             <include reference="1RA-jh-Xfd"/>
                             <include reference="sPA-I1-YzI"/>
                             <include reference="y9t-79-v13"/>
+                            <include reference="g57-te-Fqp"/>
+                            <include reference="hHz-DU-eUK"/>
                             <include reference="xAL-Mr-aiA"/>
                             <include reference="zsd-wr-B4P"/>
                             <include reference="79p-mr-0NO"/>
@@ -413,20 +419,20 @@ Title</string>
                             <include reference="fAO-vH-cgi"/>
                         </mask>
                         <mask key="constraints">
-                            <include reference="HWP-bD-q7I"/>
                             <include reference="EEn-7U-jDF"/>
                             <include reference="OYY-c7-642"/>
                             <include reference="SFG-A0-7XF"/>
                             <include reference="put-WR-Szd"/>
+                            <include reference="HWP-bD-q7I"/>
                             <include reference="MDB-2d-aWk"/>
                             <include reference="sZA-Tb-Cie"/>
-                            <include reference="g57-te-Fqp"/>
-                            <include reference="hHz-DU-eUK"/>
                             <include reference="2EN-h1-ldw"/>
                             <include reference="Bug-m8-Fqm"/>
                             <include reference="1RA-jh-Xfd"/>
                             <include reference="sPA-I1-YzI"/>
                             <include reference="y9t-79-v13"/>
+                            <include reference="g57-te-Fqp"/>
+                            <include reference="hHz-DU-eUK"/>
                             <include reference="xAL-Mr-aiA"/>
                             <include reference="zsd-wr-B4P"/>
                             <include reference="79p-mr-0NO"/>
@@ -510,6 +516,7 @@ Title</string>
                 <constraint firstItem="IVo-gm-8qs" firstAttribute="centerX" secondItem="rFH-6N-3gH" secondAttribute="centerX" id="ZsG-TS-eKR"/>
                 <constraint firstItem="NKq-bU-tvG" firstAttribute="leading" secondItem="rFH-6N-3gH" secondAttribute="leading" id="cUc-Ko-vsy"/>
                 <constraint firstItem="fi9-sW-1VX" firstAttribute="top" secondItem="rFH-6N-3gH" secondAttribute="top" id="cbb-BO-G5L"/>
+                <constraint firstAttribute="bottom" secondItem="Uc8-v7-96O" secondAttribute="bottom" constant="70" id="coa-PV-KiP"/>
                 <constraint firstItem="UtD-cb-Wlb" firstAttribute="centerX" secondItem="rFH-6N-3gH" secondAttribute="centerX" id="daT-2G-R8Z"/>
                 <constraint firstAttribute="trailing" secondItem="fi9-sW-1VX" secondAttribute="trailing" id="eNx-qY-amb"/>
                 <constraint firstItem="IVo-gm-8qs" firstAttribute="centerY" secondItem="rFH-6N-3gH" secondAttribute="centerY" constant="0.16666666666668561" id="g2S-a8-EXu"/>
@@ -521,6 +528,11 @@ Title</string>
                 <constraint firstItem="UtD-cb-Wlb" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="rFH-6N-3gH" secondAttribute="leading" constant="40" id="ute-YD-JsE"/>
                 <constraint firstItem="fi9-sW-1VX" firstAttribute="leading" secondItem="rFH-6N-3gH" secondAttribute="leading" id="vK8-8v-dJz"/>
             </constraints>
+            <variation key="default">
+                <mask key="constraints">
+                    <exclude reference="coa-PV-KiP"/>
+                </mask>
+            </variation>
             <connections>
                 <outletCollection property="gestureRecognizers" destination="ydI-nT-cAb" appends="YES" id="w9x-Nr-aVL"/>
                 <outletCollection property="gestureRecognizers" destination="ZiF-3w-BsH" appends="YES" id="gz4-El-Rax"/>

--- a/PlayerControls/resources/DefaultControlsViewController.xib
+++ b/PlayerControls/resources/DefaultControlsViewController.xib
@@ -15,8 +15,10 @@
                 <outlet property="airplayActiveLabel" destination="kPK-Sh-8jh" id="JaP-cu-vma"/>
                 <outlet property="airplayEdgeTrailingConstrains" destination="QZF-YX-TTy" id="zAV-I0-xeo"/>
                 <outlet property="airplayPipTrailingConstrains" destination="Rmc-6f-Sga" id="7AY-u1-OE5"/>
+                <outlet property="bottomItemsAndSeekerAnimatedConstraint" destination="7au-pl-AdU" id="C2t-3O-Zul"/>
+                <outlet property="bottomItemsInvisibleConstraint" destination="bIH-ZD-ij1" id="lIV-lW-rbF"/>
                 <outlet property="bottomItemsView" destination="8y7-Mc-uq8" id="KFT-1o-P2P"/>
-                <outlet property="bottomSeekBarConstraint" destination="1rA-Ma-4OD" id="thy-r3-SLe"/>
+                <outlet property="bottomItemsVisibleConstraint" destination="jGJ-02-tF0" id="6Of-Um-71Z"/>
                 <outlet property="cameraPanGestureRecognizer" destination="ZiF-3w-BsH" id="RtK-Tm-0VF"/>
                 <outlet property="ccTextLabel" destination="SEd-qf-YJr" id="RPz-r8-Q4U"/>
                 <outlet property="compasBodyView" destination="l0O-oR-0Rg" id="KC1-qR-MfN"/>
@@ -170,11 +172,11 @@ Subtitles</string>
                             </connections>
                         </button>
                         <view contentMode="scaleToFill" placeholderIntrinsicWidth="30" placeholderIntrinsicHeight="infinite" translatesAutoresizingMaskIntoConstraints="NO" id="Uc8-v7-96O" customClass="SideBarView" customModule="PlayerControls" customModuleProvider="target">
-                            <rect key="frame" x="637" y="0.0" width="30" height="281.5"/>
+                            <rect key="frame" x="637" y="0.0" width="30" height="281"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
                         <view hidden="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="57" translatesAutoresizingMaskIntoConstraints="NO" id="fAO-vH-cgi" customClass="SeekerControlView" customModule="PlayerControls" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="258.5" width="667" height="57"/>
+                            <rect key="frame" x="0.0" y="258" width="667" height="57"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <accessibility key="accessibilityConfiguration">
                                 <accessibilityTraits key="traits" adjustable="YES"/>
@@ -190,14 +192,14 @@ Subtitles</string>
                             </userDefinedRuntimeAttributes>
                         </view>
                         <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Im0-Vw-2gZ">
-                            <rect key="frame" x="618" y="312.5" width="32" height="14"/>
+                            <rect key="frame" x="618" y="312" width="32" height="14"/>
                             <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                             <color key="textColor" red="0.81568627450980391" green="0.81568627450980391" blue="0.81568627450980391" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8y7-Mc-uq8" userLabel="Bottom Items View">
-                            <rect key="frame" x="0.0" y="322" width="667" height="53"/>
+                            <rect key="frame" x="0.0" y="321.5" width="667" height="53"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="98K-SA-Pdv">
                                     <rect key="frame" x="15" y="-4" width="35" height="43"/>
@@ -240,7 +242,7 @@ Title</string>
                                     </connections>
                                 </button>
                             </subviews>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            <color key="backgroundColor" red="0.63457241490000005" green="0.84397296349999995" blue="0.91185637949999998" alpha="0.20843419894366197" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstItem="tGV-rG-prj" firstAttribute="leading" secondItem="Ddy-Jb-aVD" secondAttribute="trailing" constant="15" id="6mX-Nf-m9k"/>
                                 <constraint firstItem="Ddy-Jb-aVD" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="98K-SA-Pdv" secondAttribute="trailing" constant="15" id="DLB-gl-3Xi"/>
@@ -269,12 +271,10 @@ Title</string>
                     <gestureRecognizers/>
                     <constraints>
                         <constraint firstItem="U8A-X2-cyf" firstAttribute="leading" secondItem="cNh-R2-LdG" secondAttribute="trailing" constant="6" id="1RA-jh-Xfd"/>
-                        <constraint firstAttribute="bottom" secondItem="fAO-vH-cgi" secondAttribute="bottom" constant="60" id="1rA-Ma-4OD">
-                            <variation key="heightClass=regular" constant="65"/>
-                        </constraint>
                         <constraint firstItem="KeK-cX-xXB" firstAttribute="centerX" secondItem="U8A-X2-cyf" secondAttribute="centerX" id="2EN-h1-ldw"/>
                         <constraint firstAttribute="trailing" secondItem="m54-Yx-R7K" secondAttribute="trailing" id="3f9-SO-RA2"/>
                         <constraint firstItem="djN-u7-nkt" firstAttribute="centerY" secondItem="U8A-X2-cyf" secondAttribute="centerY" id="79p-mr-0NO"/>
+                        <constraint firstAttribute="bottom" secondItem="fAO-vH-cgi" secondAttribute="top" id="7au-pl-AdU"/>
                         <constraint firstItem="KeK-cX-xXB" firstAttribute="centerY" secondItem="U8A-X2-cyf" secondAttribute="centerY" id="Bug-m8-Fqm"/>
                         <constraint firstItem="Uc8-v7-96O" firstAttribute="top" secondItem="fi9-sW-1VX" secondAttribute="top" id="DWa-IY-lCj"/>
                         <constraint firstItem="fAO-vH-cgi" firstAttribute="top" secondItem="Uc8-v7-96O" secondAttribute="bottom" constant="-23" id="EEn-7U-jDF"/>
@@ -288,7 +288,7 @@ Title</string>
                         <constraint firstAttribute="trailing" secondItem="Uc8-v7-96O" secondAttribute="trailing" constant="0.5" id="Pzo-A9-BH0"/>
                         <constraint firstAttribute="trailing" secondItem="fAO-vH-cgi" secondAttribute="trailing" id="SFG-A0-7XF"/>
                         <constraint firstItem="8y7-Mc-uq8" firstAttribute="leading" secondItem="fi9-sW-1VX" secondAttribute="leading" id="Svu-2t-QSO"/>
-                        <constraint firstAttribute="bottom" secondItem="8y7-Mc-uq8" secondAttribute="bottom" id="bIH-ZD-ij1"/>
+                        <constraint firstAttribute="bottom" secondItem="8y7-Mc-uq8" secondAttribute="top" id="bIH-ZD-ij1"/>
                         <constraint firstItem="8y7-Mc-uq8" firstAttribute="top" secondItem="fAO-vH-cgi" secondAttribute="bottom" constant="6.5" id="dM6-vN-wjR"/>
                         <constraint firstAttribute="trailing" secondItem="Im0-Vw-2gZ" secondAttribute="trailing" constant="17" id="eTt-xT-Hay"/>
                         <constraint firstItem="m54-Yx-R7K" firstAttribute="top" secondItem="fi9-sW-1VX" secondAttribute="top" id="fv1-Ls-gs3"/>
@@ -302,6 +302,7 @@ Title</string>
                             <variation key="widthClass=compact" constant="10"/>
                             <variation key="widthClass=regular" constant="20"/>
                         </constraint>
+                        <constraint firstAttribute="bottom" secondItem="8y7-Mc-uq8" secondAttribute="bottom" id="jGJ-02-tF0"/>
                         <constraint firstItem="l0O-oR-0Rg" firstAttribute="top" secondItem="fi9-sW-1VX" secondAttribute="top" constant="20" id="mIu-gb-Ffc"/>
                         <constraint firstAttribute="trailing" secondItem="8y7-Mc-uq8" secondAttribute="trailing" id="nNG-9w-zjf"/>
                         <constraint firstItem="djN-u7-nkt" firstAttribute="leading" secondItem="U8A-X2-cyf" secondAttribute="trailing" constant="6" id="pG8-cM-rpN"/>
@@ -334,6 +335,7 @@ Title</string>
                             <exclude reference="fAO-vH-cgi"/>
                         </mask>
                         <mask key="constraints">
+                            <exclude reference="7au-pl-AdU"/>
                             <exclude reference="EEn-7U-jDF"/>
                             <exclude reference="OYY-c7-642"/>
                             <exclude reference="SFG-A0-7XF"/>
@@ -350,6 +352,7 @@ Title</string>
                             <exclude reference="hHz-DU-eUK"/>
                             <exclude reference="xAL-Mr-aiA"/>
                             <exclude reference="zsd-wr-B4P"/>
+                            <exclude reference="bIH-ZD-ij1"/>
                             <exclude reference="79p-mr-0NO"/>
                             <exclude reference="pG8-cM-rpN"/>
                             <exclude reference="F2z-D3-yET"/>

--- a/PlayerControls/resources/DefaultControlsViewController.xib
+++ b/PlayerControls/resources/DefaultControlsViewController.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="landscape">
+    <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -16,7 +16,9 @@
                 <outlet property="airplayEdgeTrailingConstrains" destination="QZF-YX-TTy" id="zAV-I0-xeo"/>
                 <outlet property="airplayPipTrailingConstrains" destination="Rmc-6f-Sga" id="7AY-u1-OE5"/>
                 <outlet property="bottomItemsAndSeekerAnimatedConstraint" destination="7au-pl-AdU" id="C2t-3O-Zul"/>
+                <outlet property="bottomItemsHeightConstraint" destination="grI-1x-tIl" id="xfT-MT-O38"/>
                 <outlet property="bottomItemsInvisibleConstraint" destination="bIH-ZD-ij1" id="lIV-lW-rbF"/>
+                <outlet property="bottomItemsSeekerConstraint" destination="dM6-vN-wjR" id="4Uf-Ja-4Cb"/>
                 <outlet property="bottomItemsView" destination="8y7-Mc-uq8" id="KFT-1o-P2P"/>
                 <outlet property="bottomItemsVisibleConstraint" destination="jGJ-02-tF0" id="6Of-Um-71Z"/>
                 <outlet property="cameraPanGestureRecognizer" destination="ZiF-3w-BsH" id="RtK-Tm-0VF"/>
@@ -64,11 +66,11 @@
             </connections>
         </tapGestureRecognizer>
         <view contentMode="scaleToFill" id="rFH-6N-3gH">
-            <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SEd-qf-YJr" userLabel="Subtitles">
-                    <rect key="frame" x="299.5" y="222" width="68" height="43"/>
+                    <rect key="frame" x="153.5" y="494" width="68" height="43"/>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.34999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                     <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <string key="text">Subtitles
@@ -78,19 +80,19 @@ Subtitles</string>
                     <nil key="highlightedColor"/>
                 </label>
                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="NKq-bU-tvG">
-                    <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                 </imageView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fi9-sW-1VX" userLabel="Controls view">
-                    <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <subviews>
                         <view alpha="0.29999999999999999" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="m54-Yx-R7K" userLabel="Shadow View">
-                            <rect key="frame" x="0.0" y="0.0" width="667" height="375"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
                         <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="icon-loading" translatesAutoresizingMaskIntoConstraints="NO" id="ikX-6f-FSq">
-                            <rect key="frame" x="286.5" y="140.5" width="95" height="95"/>
+                            <rect key="frame" x="140.5" y="286.5" width="95" height="95"/>
                             <accessibility key="accessibilityConfiguration" label="Loading content video">
                                 <bool key="isElement" value="YES"/>
                             </accessibility>
@@ -107,7 +109,7 @@ Subtitles</string>
                             <rect key="frame" x="10" y="20" width="30" height="30"/>
                         </imageView>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wVE-Q8-zOG">
-                            <rect key="frame" x="286.5" y="140.5" width="95" height="95"/>
+                            <rect key="frame" x="140.5" y="286.5" width="95" height="95"/>
                             <accessibility key="accessibilityConfiguration" label="Replay content video"/>
                             <state key="normal" image="icon-replay"/>
                             <state key="highlighted" image="icon-replay-glow"/>
@@ -116,7 +118,7 @@ Subtitles</string>
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U8A-X2-cyf" userLabel="Play Button">
-                            <rect key="frame" x="286.5" y="140.5" width="95" height="95"/>
+                            <rect key="frame" x="140.5" y="286.5" width="95" height="95"/>
                             <accessibility key="accessibilityConfiguration" label="Play content video">
                                 <accessibilityTraits key="traits" button="YES" startsMediaSession="YES"/>
                             </accessibility>
@@ -127,7 +129,7 @@ Subtitles</string>
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KeK-cX-xXB" userLabel="Pause Button">
-                            <rect key="frame" x="286.5" y="140.5" width="95" height="95"/>
+                            <rect key="frame" x="140.5" y="286.5" width="95" height="95"/>
                             <accessibility key="accessibilityConfiguration" label="Pause content video"/>
                             <state key="normal" image="icon-pause"/>
                             <state key="highlighted" image="icon-pause-glow"/>
@@ -136,7 +138,7 @@ Subtitles</string>
                             </connections>
                         </button>
                         <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ida-wI-kAP" userLabel="Next">
-                            <rect key="frame" x="439.5" y="172.5" width="22" height="32"/>
+                            <rect key="frame" x="293.5" y="318.5" width="22" height="32"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <accessibility key="accessibilityConfiguration" label="Next video"/>
                             <inset key="contentEdgeInsets" minX="0.0" minY="5" maxX="5" maxY="5"/>
@@ -147,7 +149,7 @@ Subtitles</string>
                             </connections>
                         </button>
                         <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="73i-r1-qKj" userLabel="Prev">
-                            <rect key="frame" x="205.5" y="172.5" width="23" height="32"/>
+                            <rect key="frame" x="59.5" y="318.5" width="23" height="32"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <accessibility key="accessibilityConfiguration" label="Previous video"/>
                             <inset key="contentEdgeInsets" minX="5" minY="5" maxX="0.0" maxY="5"/>
@@ -158,7 +160,7 @@ Subtitles</string>
                             </connections>
                         </button>
                         <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="djN-u7-nkt" userLabel="10 sec forward">
-                            <rect key="frame" x="387.5" y="167.5" width="42" height="42"/>
+                            <rect key="frame" x="241.5" y="313.5" width="42" height="42"/>
                             <accessibility key="accessibilityConfiguration" label="Skip 10 seconds forward"/>
                             <state key="normal" image="icon-10-sec"/>
                             <state key="highlighted" image="icon-10-sec-active"/>
@@ -167,7 +169,7 @@ Subtitles</string>
                             </connections>
                         </button>
                         <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cNh-R2-LdG" userLabel="10 sec backward">
-                            <rect key="frame" x="238.5" y="167.5" width="42" height="42"/>
+                            <rect key="frame" x="92.5" y="313.5" width="42" height="42"/>
                             <accessibility key="accessibilityConfiguration" label="Skip 10 seconds backward"/>
                             <state key="normal" image="icon-10-sec"/>
                             <state key="highlighted" image="icon-10-sec-active"/>
@@ -176,11 +178,11 @@ Subtitles</string>
                             </connections>
                         </button>
                         <view contentMode="scaleToFill" placeholderIntrinsicWidth="30" placeholderIntrinsicHeight="infinite" translatesAutoresizingMaskIntoConstraints="NO" id="Uc8-v7-96O" customClass="SideBarView" customModule="PlayerControls" customModuleProvider="target">
-                            <rect key="frame" x="636.5" y="0.0" width="30" height="287.5"/>
+                            <rect key="frame" x="344.5" y="0.0" width="30" height="571"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
                         <view hidden="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="57" translatesAutoresizingMaskIntoConstraints="NO" id="fAO-vH-cgi" customClass="SeekerControlView" customModule="PlayerControls" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="264.5" width="667" height="57"/>
+                            <rect key="frame" x="0.0" y="548" width="375" height="57"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <accessibility key="accessibilityConfiguration">
                                 <accessibilityTraits key="traits" adjustable="YES"/>
@@ -196,17 +198,17 @@ Subtitles</string>
                             </userDefinedRuntimeAttributes>
                         </view>
                         <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Im0-Vw-2gZ">
-                            <rect key="frame" x="618" y="318.5" width="32" height="14"/>
+                            <rect key="frame" x="326" y="595" width="32" height="14"/>
                             <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                             <color key="textColor" red="0.81568627450980391" green="0.81568627450980391" blue="0.81568627450980391" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8y7-Mc-uq8" userLabel="Bottom Items View">
-                            <rect key="frame" x="0.0" y="321.5" width="667" height="53"/>
+                            <rect key="frame" x="0.0" y="606.5" width="375" height="60"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="98K-SA-Pdv">
-                                    <rect key="frame" x="15" y="-4" width="35" height="43"/>
+                                    <rect key="frame" x="15" y="3" width="35" height="43"/>
                                     <string key="text">Title
 Title</string>
                                     <fontDescription key="fontDescription" type="system" pointSize="18"/>
@@ -214,7 +216,7 @@ Title</string>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ddy-Jb-aVD">
-                                    <rect key="frame" x="486" y="0.0" width="32" height="32"/>
+                                    <rect key="frame" x="194" y="7" width="32" height="32"/>
                                     <accessibility key="accessibilityConfiguration" label="Settings"/>
                                     <state key="normal" image="icon-sub">
                                         <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -225,7 +227,7 @@ Title</string>
                                     </connections>
                                 </button>
                                 <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="72o-zQ-Neb" customClass="AirPlayView" customModule="PlayerControls" customModuleProvider="target">
-                                    <rect key="frame" x="533" y="0.0" width="32" height="32"/>
+                                    <rect key="frame" x="241" y="7" width="32" height="32"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     <accessibility key="accessibilityConfiguration" label="AirPlay">
                                         <accessibilityTraits key="traits" button="YES"/>
@@ -237,7 +239,7 @@ Title</string>
                                     </constraints>
                                 </view>
                                 <button hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tGV-rG-prj" userLabel="PiP">
-                                    <rect key="frame" x="580" y="0.0" width="32" height="32"/>
+                                    <rect key="frame" x="288" y="7" width="32" height="32"/>
                                     <accessibility key="accessibilityConfiguration" label="Picture in picture"/>
                                     <state key="normal" image="icon-pip"/>
                                     <state key="highlighted" image="icon-pip-active"/>
@@ -259,7 +261,7 @@ Title</string>
                                 <constraint firstAttribute="trailing" secondItem="tGV-rG-prj" secondAttribute="trailing" constant="55" id="YjR-Vc-LlO"/>
                                 <constraint firstItem="72o-zQ-Neb" firstAttribute="leading" secondItem="Ddy-Jb-aVD" secondAttribute="trailing" constant="15" id="fee-ei-GwZ"/>
                                 <constraint firstAttribute="trailing" secondItem="Ddy-Jb-aVD" secondAttribute="trailing" constant="55" id="geE-p0-gZ0"/>
-                                <constraint firstAttribute="height" constant="53" id="grI-1x-tIl"/>
+                                <constraint firstAttribute="height" constant="60" id="grI-1x-tIl"/>
                                 <constraint firstItem="98K-SA-Pdv" firstAttribute="leading" secondItem="8y7-Mc-uq8" secondAttribute="leading" constant="15" id="r0o-DX-aP2"/>
                             </constraints>
                             <variation key="default">
@@ -294,7 +296,7 @@ Title</string>
                         <constraint firstItem="8y7-Mc-uq8" firstAttribute="leading" secondItem="fi9-sW-1VX" secondAttribute="leading" id="Svu-2t-QSO"/>
                         <constraint firstAttribute="trailing" secondItem="Uc8-v7-96O" secondAttribute="trailing" constant="-31" id="Yy9-r3-97c"/>
                         <constraint firstAttribute="bottom" secondItem="8y7-Mc-uq8" secondAttribute="top" id="bIH-ZD-ij1"/>
-                        <constraint firstItem="8y7-Mc-uq8" firstAttribute="top" secondItem="fAO-vH-cgi" secondAttribute="bottom" constant="0.14999999999999999" id="dM6-vN-wjR"/>
+                        <constraint firstItem="8y7-Mc-uq8" firstAttribute="top" secondItem="fAO-vH-cgi" secondAttribute="bottom" constant="1.5" id="dM6-vN-wjR"/>
                         <constraint firstAttribute="trailing" secondItem="Im0-Vw-2gZ" secondAttribute="trailing" constant="17" id="eTt-xT-Hay"/>
                         <constraint firstItem="m54-Yx-R7K" firstAttribute="top" secondItem="fi9-sW-1VX" secondAttribute="top" id="fv1-Ls-gs3"/>
                         <constraint firstItem="ikX-6f-FSq" firstAttribute="centerY" secondItem="U8A-X2-cyf" secondAttribute="centerY" id="g57-te-Fqp"/>
@@ -340,24 +342,24 @@ Title</string>
                             <exclude reference="fAO-vH-cgi"/>
                         </mask>
                         <mask key="constraints">
+                            <exclude reference="HWP-bD-q7I"/>
+                            <exclude reference="MDB-2d-aWk"/>
+                            <exclude reference="sZA-Tb-Cie"/>
                             <exclude reference="7au-pl-AdU"/>
                             <exclude reference="EEn-7U-jDF"/>
                             <exclude reference="OYY-c7-642"/>
                             <exclude reference="SFG-A0-7XF"/>
                             <exclude reference="put-WR-Szd"/>
-                            <exclude reference="HWP-bD-q7I"/>
-                            <exclude reference="MDB-2d-aWk"/>
-                            <exclude reference="sZA-Tb-Cie"/>
+                            <exclude reference="g57-te-Fqp"/>
+                            <exclude reference="hHz-DU-eUK"/>
+                            <exclude reference="bIH-ZD-ij1"/>
                             <exclude reference="2EN-h1-ldw"/>
                             <exclude reference="Bug-m8-Fqm"/>
                             <exclude reference="1RA-jh-Xfd"/>
                             <exclude reference="sPA-I1-YzI"/>
                             <exclude reference="y9t-79-v13"/>
-                            <exclude reference="g57-te-Fqp"/>
-                            <exclude reference="hHz-DU-eUK"/>
                             <exclude reference="xAL-Mr-aiA"/>
                             <exclude reference="zsd-wr-B4P"/>
-                            <exclude reference="bIH-ZD-ij1"/>
                             <exclude reference="79p-mr-0NO"/>
                             <exclude reference="pG8-cM-rpN"/>
                             <exclude reference="F2z-D3-yET"/>
@@ -381,20 +383,20 @@ Title</string>
                             <include reference="fAO-vH-cgi"/>
                         </mask>
                         <mask key="constraints">
+                            <include reference="HWP-bD-q7I"/>
+                            <include reference="MDB-2d-aWk"/>
+                            <include reference="sZA-Tb-Cie"/>
                             <include reference="EEn-7U-jDF"/>
                             <include reference="OYY-c7-642"/>
                             <include reference="SFG-A0-7XF"/>
                             <include reference="put-WR-Szd"/>
-                            <include reference="HWP-bD-q7I"/>
-                            <include reference="MDB-2d-aWk"/>
-                            <include reference="sZA-Tb-Cie"/>
+                            <include reference="g57-te-Fqp"/>
+                            <include reference="hHz-DU-eUK"/>
                             <include reference="2EN-h1-ldw"/>
                             <include reference="Bug-m8-Fqm"/>
                             <include reference="1RA-jh-Xfd"/>
                             <include reference="sPA-I1-YzI"/>
                             <include reference="y9t-79-v13"/>
-                            <include reference="g57-te-Fqp"/>
-                            <include reference="hHz-DU-eUK"/>
                             <include reference="xAL-Mr-aiA"/>
                             <include reference="zsd-wr-B4P"/>
                             <include reference="79p-mr-0NO"/>
@@ -419,20 +421,20 @@ Title</string>
                             <include reference="fAO-vH-cgi"/>
                         </mask>
                         <mask key="constraints">
+                            <include reference="HWP-bD-q7I"/>
+                            <include reference="MDB-2d-aWk"/>
+                            <include reference="sZA-Tb-Cie"/>
                             <include reference="EEn-7U-jDF"/>
                             <include reference="OYY-c7-642"/>
                             <include reference="SFG-A0-7XF"/>
                             <include reference="put-WR-Szd"/>
-                            <include reference="HWP-bD-q7I"/>
-                            <include reference="MDB-2d-aWk"/>
-                            <include reference="sZA-Tb-Cie"/>
+                            <include reference="g57-te-Fqp"/>
+                            <include reference="hHz-DU-eUK"/>
                             <include reference="2EN-h1-ldw"/>
                             <include reference="Bug-m8-Fqm"/>
                             <include reference="1RA-jh-Xfd"/>
                             <include reference="sPA-I1-YzI"/>
                             <include reference="y9t-79-v13"/>
-                            <include reference="g57-te-Fqp"/>
-                            <include reference="hHz-DU-eUK"/>
                             <include reference="xAL-Mr-aiA"/>
                             <include reference="zsd-wr-B4P"/>
                             <include reference="79p-mr-0NO"/>
@@ -446,19 +448,19 @@ Title</string>
                     </variation>
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This video is playing on Apple TV" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kPK-Sh-8jh">
-                    <rect key="frame" x="220" y="102" width="227" height="18"/>
+                    <rect key="frame" x="74" y="248" width="227" height="18"/>
                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UtD-cb-Wlb" userLabel="Error">
-                    <rect key="frame" x="333.5" y="127.5" width="0.0" height="0.0"/>
+                    <rect key="frame" x="187.5" y="273.5" width="0.0" height="0.0"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IVo-gm-8qs">
-                    <rect key="frame" x="286" y="140" width="95" height="95"/>
+                    <rect key="frame" x="140" y="286" width="95" height="95"/>
                     <accessibility key="accessibilityConfiguration" label="Retry to load content video"/>
                     <state key="normal" image="icon-replay"/>
                     <connections>
@@ -537,7 +539,7 @@ Title</string>
                 <outletCollection property="gestureRecognizers" destination="ydI-nT-cAb" appends="YES" id="w9x-Nr-aVL"/>
                 <outletCollection property="gestureRecognizers" destination="ZiF-3w-BsH" appends="YES" id="gz4-El-Rax"/>
             </connections>
-            <point key="canvasLocation" x="33.5" y="52.5"/>
+            <point key="canvasLocation" x="32.5" y="51.5"/>
         </view>
         <panGestureRecognizer minimumNumberOfTouches="1" maximumNumberOfTouches="1" id="ZiF-3w-BsH">
             <connections>

--- a/PlayerControls/resources/DefaultControlsViewController.xib
+++ b/PlayerControls/resources/DefaultControlsViewController.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
+    <device id="retina3_5" orientation="landscape">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -66,11 +66,11 @@
             </connections>
         </tapGestureRecognizer>
         <view contentMode="scaleToFill" id="rFH-6N-3gH">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+            <rect key="frame" x="0.0" y="0.0" width="480" height="320"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SEd-qf-YJr" userLabel="Subtitles">
-                    <rect key="frame" x="153.5" y="494" width="68" height="43"/>
+                    <rect key="frame" x="206" y="167" width="68" height="43"/>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.34999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                     <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <string key="text">Subtitles
@@ -80,19 +80,19 @@ Subtitles</string>
                     <nil key="highlightedColor"/>
                 </label>
                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="NKq-bU-tvG">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <rect key="frame" x="0.0" y="0.0" width="480" height="320"/>
                     <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                 </imageView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fi9-sW-1VX" userLabel="Controls view">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <rect key="frame" x="0.0" y="0.0" width="480" height="320"/>
                     <subviews>
                         <view alpha="0.29999999999999999" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="m54-Yx-R7K" userLabel="Shadow View">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                            <rect key="frame" x="0.0" y="0.0" width="480" height="320"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
                         <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="icon-loading" translatesAutoresizingMaskIntoConstraints="NO" id="ikX-6f-FSq">
-                            <rect key="frame" x="140.5" y="286.5" width="95" height="95"/>
+                            <rect key="frame" x="193" y="113" width="95" height="95"/>
                             <accessibility key="accessibilityConfiguration" label="Loading content video">
                                 <bool key="isElement" value="YES"/>
                             </accessibility>
@@ -109,7 +109,7 @@ Subtitles</string>
                             <rect key="frame" x="10" y="20" width="30" height="30"/>
                         </imageView>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wVE-Q8-zOG">
-                            <rect key="frame" x="140.5" y="286.5" width="95" height="95"/>
+                            <rect key="frame" x="193" y="113" width="95" height="95"/>
                             <accessibility key="accessibilityConfiguration" label="Replay content video"/>
                             <state key="normal" image="icon-replay"/>
                             <state key="highlighted" image="icon-replay-glow"/>
@@ -118,7 +118,7 @@ Subtitles</string>
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U8A-X2-cyf" userLabel="Play Button">
-                            <rect key="frame" x="140.5" y="286.5" width="95" height="95"/>
+                            <rect key="frame" x="193" y="113" width="95" height="95"/>
                             <accessibility key="accessibilityConfiguration" label="Play content video">
                                 <accessibilityTraits key="traits" button="YES" startsMediaSession="YES"/>
                             </accessibility>
@@ -129,7 +129,7 @@ Subtitles</string>
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KeK-cX-xXB" userLabel="Pause Button">
-                            <rect key="frame" x="140.5" y="286.5" width="95" height="95"/>
+                            <rect key="frame" x="193" y="113" width="95" height="95"/>
                             <accessibility key="accessibilityConfiguration" label="Pause content video"/>
                             <state key="normal" image="icon-pause"/>
                             <state key="highlighted" image="icon-pause-glow"/>
@@ -138,7 +138,7 @@ Subtitles</string>
                             </connections>
                         </button>
                         <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ida-wI-kAP" userLabel="Next">
-                            <rect key="frame" x="293.5" y="318.5" width="22" height="32"/>
+                            <rect key="frame" x="346" y="145" width="22" height="32"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <accessibility key="accessibilityConfiguration" label="Next video"/>
                             <inset key="contentEdgeInsets" minX="0.0" minY="5" maxX="5" maxY="5"/>
@@ -149,7 +149,7 @@ Subtitles</string>
                             </connections>
                         </button>
                         <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="73i-r1-qKj" userLabel="Prev">
-                            <rect key="frame" x="59.5" y="318.5" width="23" height="32"/>
+                            <rect key="frame" x="112" y="145" width="23" height="32"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <accessibility key="accessibilityConfiguration" label="Previous video"/>
                             <inset key="contentEdgeInsets" minX="5" minY="5" maxX="0.0" maxY="5"/>
@@ -160,7 +160,7 @@ Subtitles</string>
                             </connections>
                         </button>
                         <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="djN-u7-nkt" userLabel="10 sec forward">
-                            <rect key="frame" x="241.5" y="313.5" width="42" height="42"/>
+                            <rect key="frame" x="294" y="140" width="42" height="42"/>
                             <accessibility key="accessibilityConfiguration" label="Skip 10 seconds forward"/>
                             <state key="normal" image="icon-10-sec"/>
                             <state key="highlighted" image="icon-10-sec-active"/>
@@ -169,7 +169,7 @@ Subtitles</string>
                             </connections>
                         </button>
                         <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cNh-R2-LdG" userLabel="10 sec backward">
-                            <rect key="frame" x="92.5" y="313.5" width="42" height="42"/>
+                            <rect key="frame" x="145" y="140" width="42" height="42"/>
                             <accessibility key="accessibilityConfiguration" label="Skip 10 seconds backward"/>
                             <state key="normal" image="icon-10-sec"/>
                             <state key="highlighted" image="icon-10-sec-active"/>
@@ -178,11 +178,11 @@ Subtitles</string>
                             </connections>
                         </button>
                         <view contentMode="scaleToFill" placeholderIntrinsicWidth="30" placeholderIntrinsicHeight="infinite" translatesAutoresizingMaskIntoConstraints="NO" id="Uc8-v7-96O" customClass="SideBarView" customModule="PlayerControls" customModuleProvider="target">
-                            <rect key="frame" x="344.5" y="0.0" width="30" height="571"/>
+                            <rect key="frame" x="449.5" y="0.0" width="30" height="226"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
                         <view hidden="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="57" translatesAutoresizingMaskIntoConstraints="NO" id="fAO-vH-cgi" customClass="SeekerControlView" customModule="PlayerControls" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="548" width="375" height="57"/>
+                            <rect key="frame" x="0.0" y="203" width="480" height="55"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <accessibility key="accessibilityConfiguration">
                                 <accessibilityTraits key="traits" adjustable="YES"/>
@@ -198,14 +198,14 @@ Subtitles</string>
                             </userDefinedRuntimeAttributes>
                         </view>
                         <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Im0-Vw-2gZ">
-                            <rect key="frame" x="326" y="595" width="32" height="14"/>
+                            <rect key="frame" x="431" y="255" width="32" height="14"/>
                             <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                             <color key="textColor" red="0.81568627450980391" green="0.81568627450980391" blue="0.81568627450980391" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8y7-Mc-uq8" userLabel="Bottom Items View">
-                            <rect key="frame" x="0.0" y="606.5" width="375" height="60"/>
+                            <rect key="frame" x="0.0" y="259.5" width="480" height="60"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="98K-SA-Pdv">
                                     <rect key="frame" x="15" y="3" width="35" height="43"/>
@@ -216,7 +216,7 @@ Title</string>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ddy-Jb-aVD">
-                                    <rect key="frame" x="194" y="7" width="32" height="32"/>
+                                    <rect key="frame" x="299" y="7" width="32" height="32"/>
                                     <accessibility key="accessibilityConfiguration" label="Settings"/>
                                     <state key="normal" image="icon-sub">
                                         <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -227,7 +227,7 @@ Title</string>
                                     </connections>
                                 </button>
                                 <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="72o-zQ-Neb" customClass="AirPlayView" customModule="PlayerControls" customModuleProvider="target">
-                                    <rect key="frame" x="241" y="7" width="32" height="32"/>
+                                    <rect key="frame" x="346" y="7" width="32" height="32"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     <accessibility key="accessibilityConfiguration" label="AirPlay">
                                         <accessibilityTraits key="traits" button="YES"/>
@@ -239,7 +239,7 @@ Title</string>
                                     </constraints>
                                 </view>
                                 <button hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tGV-rG-prj" userLabel="PiP">
-                                    <rect key="frame" x="288" y="7" width="32" height="32"/>
+                                    <rect key="frame" x="393" y="7" width="32" height="32"/>
                                     <accessibility key="accessibilityConfiguration" label="Picture in picture"/>
                                     <state key="normal" image="icon-pip"/>
                                     <state key="highlighted" image="icon-pip-active"/>
@@ -283,7 +283,7 @@ Title</string>
                         <constraint firstAttribute="bottom" secondItem="fAO-vH-cgi" secondAttribute="top" id="7au-pl-AdU"/>
                         <constraint firstItem="KeK-cX-xXB" firstAttribute="centerY" secondItem="U8A-X2-cyf" secondAttribute="centerY" id="Bug-m8-Fqm"/>
                         <constraint firstItem="Uc8-v7-96O" firstAttribute="top" secondItem="fi9-sW-1VX" secondAttribute="top" id="DWa-IY-lCj"/>
-                        <constraint firstItem="fAO-vH-cgi" firstAttribute="top" secondItem="Uc8-v7-96O" secondAttribute="bottom" constant="-23" id="EEn-7U-jDF"/>
+                        <constraint firstItem="fAO-vH-cgi" firstAttribute="top" secondItem="Uc8-v7-96O" secondAttribute="bottom" priority="750" constant="-23" id="EEn-7U-jDF"/>
                         <constraint firstItem="ida-wI-kAP" firstAttribute="centerY" secondItem="djN-u7-nkt" secondAttribute="centerY" id="F2z-D3-yET"/>
                         <constraint firstItem="73i-r1-qKj" firstAttribute="centerY" secondItem="cNh-R2-LdG" secondAttribute="centerY" id="HWP-bD-q7I"/>
                         <constraint firstItem="6eW-2a-aeL" firstAttribute="centerX" secondItem="l0O-oR-0Rg" secondAttribute="centerX" id="HlO-Pl-IWR"/>
@@ -345,14 +345,8 @@ Title</string>
                             <exclude reference="HWP-bD-q7I"/>
                             <exclude reference="MDB-2d-aWk"/>
                             <exclude reference="sZA-Tb-Cie"/>
-                            <exclude reference="7au-pl-AdU"/>
-                            <exclude reference="EEn-7U-jDF"/>
-                            <exclude reference="OYY-c7-642"/>
-                            <exclude reference="SFG-A0-7XF"/>
-                            <exclude reference="put-WR-Szd"/>
                             <exclude reference="g57-te-Fqp"/>
                             <exclude reference="hHz-DU-eUK"/>
-                            <exclude reference="bIH-ZD-ij1"/>
                             <exclude reference="2EN-h1-ldw"/>
                             <exclude reference="Bug-m8-Fqm"/>
                             <exclude reference="1RA-jh-Xfd"/>
@@ -364,10 +358,16 @@ Title</string>
                             <exclude reference="pG8-cM-rpN"/>
                             <exclude reference="F2z-D3-yET"/>
                             <exclude reference="iww-Ws-dSP"/>
+                            <exclude reference="7au-pl-AdU"/>
+                            <exclude reference="EEn-7U-jDF"/>
                             <exclude reference="DWa-IY-lCj"/>
                             <exclude reference="Pzo-A9-BH0"/>
                             <exclude reference="Yy9-r3-97c"/>
+                            <exclude reference="bIH-ZD-ij1"/>
                             <exclude reference="eTt-xT-Hay"/>
+                            <exclude reference="OYY-c7-642"/>
+                            <exclude reference="SFG-A0-7XF"/>
+                            <exclude reference="put-WR-Szd"/>
                         </mask>
                     </variation>
                     <variation key="widthClass=compact">
@@ -386,10 +386,6 @@ Title</string>
                             <include reference="HWP-bD-q7I"/>
                             <include reference="MDB-2d-aWk"/>
                             <include reference="sZA-Tb-Cie"/>
-                            <include reference="EEn-7U-jDF"/>
-                            <include reference="OYY-c7-642"/>
-                            <include reference="SFG-A0-7XF"/>
-                            <include reference="put-WR-Szd"/>
                             <include reference="g57-te-Fqp"/>
                             <include reference="hHz-DU-eUK"/>
                             <include reference="2EN-h1-ldw"/>
@@ -403,9 +399,13 @@ Title</string>
                             <include reference="pG8-cM-rpN"/>
                             <include reference="F2z-D3-yET"/>
                             <include reference="iww-Ws-dSP"/>
+                            <include reference="EEn-7U-jDF"/>
                             <include reference="DWa-IY-lCj"/>
                             <include reference="Pzo-A9-BH0"/>
                             <include reference="eTt-xT-Hay"/>
+                            <include reference="OYY-c7-642"/>
+                            <include reference="SFG-A0-7XF"/>
+                            <include reference="put-WR-Szd"/>
                         </mask>
                     </variation>
                     <variation key="widthClass=regular">
@@ -424,10 +424,6 @@ Title</string>
                             <include reference="HWP-bD-q7I"/>
                             <include reference="MDB-2d-aWk"/>
                             <include reference="sZA-Tb-Cie"/>
-                            <include reference="EEn-7U-jDF"/>
-                            <include reference="OYY-c7-642"/>
-                            <include reference="SFG-A0-7XF"/>
-                            <include reference="put-WR-Szd"/>
                             <include reference="g57-te-Fqp"/>
                             <include reference="hHz-DU-eUK"/>
                             <include reference="2EN-h1-ldw"/>
@@ -441,26 +437,30 @@ Title</string>
                             <include reference="pG8-cM-rpN"/>
                             <include reference="F2z-D3-yET"/>
                             <include reference="iww-Ws-dSP"/>
+                            <include reference="EEn-7U-jDF"/>
                             <include reference="DWa-IY-lCj"/>
                             <include reference="Pzo-A9-BH0"/>
                             <include reference="eTt-xT-Hay"/>
+                            <include reference="OYY-c7-642"/>
+                            <include reference="SFG-A0-7XF"/>
+                            <include reference="put-WR-Szd"/>
                         </mask>
                     </variation>
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This video is playing on Apple TV" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kPK-Sh-8jh">
-                    <rect key="frame" x="74" y="248" width="227" height="18"/>
+                    <rect key="frame" x="126.5" y="74.5" width="227" height="18"/>
                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UtD-cb-Wlb" userLabel="Error">
-                    <rect key="frame" x="187.5" y="273.5" width="0.0" height="0.0"/>
+                    <rect key="frame" x="240" y="100" width="0.0" height="0.0"/>
                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IVo-gm-8qs">
-                    <rect key="frame" x="140" y="286" width="95" height="95"/>
+                    <rect key="frame" x="192.5" y="112.5" width="95" height="95"/>
                     <accessibility key="accessibilityConfiguration" label="Retry to load content video"/>
                     <state key="normal" image="icon-replay"/>
                     <connections>

--- a/PlayerControls/sources/AnimationDelegate.swift
+++ b/PlayerControls/sources/AnimationDelegate.swift
@@ -1,0 +1,21 @@
+//  Copyright © 2017 Oath. All rights reserved.
+
+import Foundation
+
+final class AnimationDelegate: NSObject, CAAnimationDelegate {
+    let didStart: ((CAAnimation) -> ())?
+    let didStop: ((CAAnimation, Bool) -> ())?
+    
+    init(didStart: ((CAAnimation) -> ())? = nil, didStop: ((CAAnimation, Bool) -> ())? = nil) {
+        self.didStart = didStart
+        self.didStop = didStop
+    }
+    
+    func animationDidStart(_ anim: CAAnimation) {
+        self.didStart?(anim)
+    }
+    
+    func animationDidStop(_ anim: CAAnimation, finished flag: Bool) {
+        self.didStop?(anim, flag)
+    }
+}

--- a/PlayerControls/sources/ContentControlsUIProps+Init.swift
+++ b/PlayerControls/sources/ContentControlsUIProps+Init.swift
@@ -4,9 +4,11 @@ import Foundation
 
 extension ContentControlsViewController.Props.Player {
     public init(playlist: ContentControlsViewController.Props.Playlist?,
-                item: ContentControlsViewController.Props.Item) {
+                item: ContentControlsViewController.Props.Item,
+                animationsEnabled: Bool) {
         self.playlist = playlist
         self.item = item
+        self.animationsEnabled = animationsEnabled
     }
 }
 

--- a/PlayerControls/sources/ContentControlsUIProps.swift
+++ b/PlayerControls/sources/ContentControlsUIProps.swift
@@ -80,6 +80,8 @@ extension DefaultControlsViewController {
         var liveIndicationViewIsHidden: Bool
         var liveDotColor: UIColor?
         
+        var animationsEnabled: Bool
+        
         //swiftlint:disable function_body_length
         //swiftlint:disable cyclomatic_complexity
         init(props: Props, controlsViewVisible: Bool) {
@@ -251,6 +253,8 @@ extension DefaultControlsViewController {
             liveIndicationViewIsHidden = props.player?.item.playable?.live.isHidden ?? true
             
             liveDotColor = props.player?.item.playable?.live.dotColor?.color ?? nil
+            
+            animationsEnabled = props.player?.animationsEnabled ?? false
             
             compassViewBelowLive = {
                 guard

--- a/PlayerControls/sources/ContentControlsUIProps.swift
+++ b/PlayerControls/sources/ContentControlsUIProps.swift
@@ -35,7 +35,7 @@ extension DefaultControlsViewController {
         var seekToSecondsAction: CommandWith<Int>
         var seekBackButtonHidden: Bool
         var seekForwardButtonHidden: Bool
-        var botoomItemsHidden: Bool
+        var bottomItemsHidden: Bool
         
         var sideBarViewHidden: Bool
         
@@ -166,7 +166,7 @@ extension DefaultControlsViewController {
             
             seekerViewBuffered = CGFloat(props.player?.item.playable?.seekbar?.buffered.value ?? 0)
             
-            botoomItemsHidden = {
+            bottomItemsHidden = {
                 guard let playable = props.player?.item.playable else { return false }
                 let hasNoTitle = playable.title.count == 0
                 let hasNoSettings = playable.settings.isHidden

--- a/PlayerControls/sources/ContentControlsUIProps.swift
+++ b/PlayerControls/sources/ContentControlsUIProps.swift
@@ -83,60 +83,61 @@ extension DefaultControlsViewController {
         //swiftlint:disable function_body_length
         //swiftlint:disable cyclomatic_complexity
         init(props: Props, controlsViewVisible: Bool) {
-            controlsViewHidden = {
+             let controlsHidden: Bool = {
                 let isPlayerAbsent = props.player == nil
                 let isControlsViewHidden = !controlsViewVisible
                 let isAirPlayInactive = !(props.player?.item.playable?.airplay.isActive ?? false)
                 
                 return isPlayerAbsent || (isControlsViewHidden && isAirPlayInactive)
             }()
+            controlsViewHidden = controlsHidden
             
             loading = props.player?.item.playable?.loading ?? false
             
-            playButtonHidden = props.player?.item.playable?.playbackAction.play == nil
+            playButtonHidden = props.player?.item.playable?.playbackAction.play == nil || controlsHidden
             
             playButtonAction = props.player?.item.playable?.playbackAction.play ?? .nop
             
-            pauseButtonHidden = props.player?.item.playable?.playbackAction.pause == nil
+            pauseButtonHidden = props.player?.item.playable?.playbackAction.pause == nil || controlsHidden
             
             pauseButtonAction = props.player?.item.playable?.playbackAction.pause ?? .nop
             
-            replayButtonHidden = props.player?.item.playable?.playbackAction.replay == nil
+            replayButtonHidden = props.player?.item.playable?.playbackAction.replay == nil || controlsHidden
             
             replayButtonAction = props.player?.item.playable?.playbackAction.replay ?? .nop
             
-            nextButtonEnabled = props.player?.playlist?.next != nil
+            nextButtonEnabled = props.player?.playlist?.next != nil || controlsHidden
             
             nextButtonAction = props.player?.playlist?.next ?? .nop
             
-            prevButtonEnabled = props.player?.playlist?.prev != nil
+            prevButtonEnabled = props.player?.playlist?.prev != nil || controlsHidden
             
             prevButtonAction = props.player?.playlist?.prev ?? .nop
             
             let nextButtonDisabled = !nextButtonEnabled
             let prevButtonDisabled = !prevButtonEnabled
             
-            prevButtonHidden = nextButtonDisabled && prevButtonDisabled
+            prevButtonHidden = (nextButtonDisabled && prevButtonDisabled) || controlsHidden
             
-            nextButtonHidden = nextButtonDisabled && prevButtonDisabled
+            nextButtonHidden = (nextButtonDisabled && prevButtonDisabled) || controlsHidden
             
-            seekerViewHidden = props.player?.item.playable?.seekbar == nil
+            seekerViewHidden = props.player?.item.playable?.seekbar == nil || controlsHidden
             
             durationTextLabelAccessibilityLabel = {
                 guard let duration = props.player?.item.playable?.seekbar?.duration else { return "" }
                 return TimeFormatter.voiceOverReadable(from: duration) ?? ""
             }()
             
-            durationTextHidden = props.player?.item.playable?.seekbar == nil
+            durationTextHidden = props.player?.item.playable?.seekbar == nil || controlsHidden
             
             durationTextLabelText = {
                 guard let seekbar = props.player?.item.playable?.seekbar else { return "" }
                 return TimeFormatter.string(from: seekbar.duration)
             }()
             
-            seekBackButtonHidden = props.player?.item.playable?.seekbar?.seeker.seekTo == nil
+            seekBackButtonHidden = props.player?.item.playable?.seekbar?.seeker.seekTo == nil || controlsHidden
             
-            seekForwardButtonHidden = props.player?.item.playable?.seekbar?.seeker.seekTo == nil
+            seekForwardButtonHidden = props.player?.item.playable?.seekbar?.seeker.seekTo == nil || controlsHidden
             
             seekToSecondsAction = props.player?.item.playable?.seekbar?.seeker.seekTo ?? .nop
             
@@ -174,11 +175,11 @@ extension DefaultControlsViewController {
                 return hasNoTitle && hasNoSettings && hasNoPipButton && hasNoAirplayButton
             }()
             
-            sideBarViewHidden = props.player?.item.playable?.sideBarViewHidden ?? true
+            sideBarViewHidden = (props.player?.item.playable?.sideBarViewHidden ?? true) || controlsHidden
             
-            compasBodyViewHidden = props.player?.item.playable?.camera == nil
+            compasBodyViewHidden = props.player?.item.playable?.camera == nil || controlsHidden
             
-            compasDirectionViewHidden = props.player?.item.playable?.camera == nil
+            compasDirectionViewHidden = props.player?.item.playable?.camera == nil || controlsHidden
             
             compasDirectionViewTransform = {
                 guard let camera = props.player?.item.playable?.camera else { return CGAffineTransform.identity }
@@ -200,9 +201,9 @@ extension DefaultControlsViewController {
                 return camera.moveTo.bind(to: .init(horizontal: 0.0, vertical: 0.0))
             }()
             
-            cameraPanGestureIsEnabled = props.player?.item.playable?.camera != nil
+            cameraPanGestureIsEnabled = props.player?.item.playable?.camera != nil || controlsHidden
         
-            videoTitleLabelHidden = props.player?.item.playable == nil
+            videoTitleLabelHidden = props.player?.item.playable == nil || controlsHidden
             
             videoTitleLabelText = props.player?.item.playable?.title ?? ""
             
@@ -216,9 +217,9 @@ extension DefaultControlsViewController {
                 }
             }()
             
-            subtitlesTextLabelHidden = props.player?.item.playable?.legible.external?.external.available?.isInactive ?? false
+            subtitlesTextLabelHidden = (props.player?.item.playable?.legible.external?.external.available?.isInactive ?? false) || controlsHidden
             
-            thumbnailImageViewHidden = props.player?.item.playable?.thumbnail?.url == nil
+            thumbnailImageViewHidden = props.player?.item.playable?.thumbnail?.url == nil || controlsHidden
             
             thumbnailImageUrl = props.player?.item.playable?.thumbnail?.url
             
@@ -226,26 +227,26 @@ extension DefaultControlsViewController {
             
             errorLabelText = props.player?.item.nonplayable ?? props.player?.item.playable?.error?.message ?? ""
             
-            errorLabelHidden = (props.player?.item.nonplayable == nil) && (props.player?.item.playable?.error == nil)
+            errorLabelHidden = (props.player?.item.nonplayable == nil) && (props.player?.item.playable?.error == nil) || controlsHidden
             
-            retryButtonHidden = props.player?.item.playable?.error == nil
+            retryButtonHidden = props.player?.item.playable?.error == nil || controlsHidden
             
             retryButtonAction = props.player?.item.playable?.error?.retryAction ?? .nop
             
-            pipButtonHidden = props.player?.item.playable?.pictureInPictureControl.isUnsupported ?? true
+            pipButtonHidden = (props.player?.item.playable?.pictureInPictureControl.isUnsupported ?? true) || controlsHidden
             
             pipButtonEnabled = props.player?.item.playable?.pictureInPictureControl.possible != nil
             
             pipButtonAction = props.player?.item.playable?.pictureInPictureControl.possible ?? .nop
             
-            settingsButtonHidden = props.player?.item.playable?.settings.isHidden ?? true
+            settingsButtonHidden = (props.player?.item.playable?.settings.isHidden ?? true) || controlsHidden
             
             settingsButtonEnabled = props.player?.item.playable?.settings.enabled != nil
             
             settingsButtonAction = props.player?.item.playable?.settings.enabled ?? .nop
             
-            airplayActiveLabelHidden = !(props.player?.item.playable?.airplay.isActive ?? false)
-            airplayButtonHidden = props.player?.item.playable?.airplay.isHidden ?? true
+            airplayActiveLabelHidden = !(props.player?.item.playable?.airplay.isActive ?? false) || controlsHidden
+            airplayButtonHidden = (props.player?.item.playable?.airplay.isHidden ?? true) || controlsHidden
             
             liveIndicationViewIsHidden = props.player?.item.playable?.live.isHidden ?? true
             

--- a/PlayerControls/sources/ContentControlsUIProps.swift
+++ b/PlayerControls/sources/ContentControlsUIProps.swift
@@ -80,6 +80,13 @@ extension DefaultControlsViewController {
         var liveIndicationViewIsHidden: Bool
         var liveDotColor: UIColor?
         
+        var bottomItemsHidden: Bool {
+            return pipButtonHidden
+                && airplayButtonHidden
+                && settingsButtonHidden
+                && (videoTitleLabelHidden || videoTitleLabelText == "")
+        }
+        
         //swiftlint:disable function_body_length
         //swiftlint:disable cyclomatic_complexity
         init(props: Props, controlsViewVisible: Bool) {

--- a/PlayerControls/sources/ContentControlsUIProps.swift
+++ b/PlayerControls/sources/ContentControlsUIProps.swift
@@ -35,7 +35,7 @@ extension DefaultControlsViewController {
         var seekToSecondsAction: CommandWith<Int>
         var seekBackButtonHidden: Bool
         var seekForwardButtonHidden: Bool
-        var seekbarPositionedAtBottom: Bool
+        var botoomItemsHidden: Bool
         
         var sideBarViewHidden: Bool
         
@@ -79,13 +79,6 @@ extension DefaultControlsViewController {
         
         var liveIndicationViewIsHidden: Bool
         var liveDotColor: UIColor?
-        
-        var bottomItemsHidden: Bool {
-            return pipButtonHidden
-                && airplayButtonHidden
-                && settingsButtonHidden
-                && (videoTitleLabelHidden || videoTitleLabelText == "")
-        }
         
         //swiftlint:disable function_body_length
         //swiftlint:disable cyclomatic_complexity
@@ -173,13 +166,13 @@ extension DefaultControlsViewController {
             
             seekerViewBuffered = CGFloat(props.player?.item.playable?.seekbar?.buffered.value ?? 0)
             
-            seekbarPositionedAtBottom = {
+            botoomItemsHidden = {
                 guard let playable = props.player?.item.playable else { return false }
                 let hasNoTitle = playable.title.count == 0
                 let hasNoSettings = playable.settings.isHidden
                 let hasNoPipButton = playable.pictureInPictureControl.isUnsupported
                 let hasNoAirplayButton = playable.airplay.isHidden
-                return hasNoTitle && hasNoSettings && hasNoPipButton && hasNoAirplayButton
+                return (hasNoTitle && hasNoSettings && hasNoPipButton && hasNoAirplayButton) || controlsHidden
             }()
             
             sideBarViewHidden = (props.player?.item.playable?.sideBarViewHidden ?? true) || controlsHidden

--- a/PlayerControls/sources/ContentControlsUIProps.swift
+++ b/PlayerControls/sources/ContentControlsUIProps.swift
@@ -224,7 +224,7 @@ extension DefaultControlsViewController {
                 }
             }()
             
-            subtitlesTextLabelHidden = (props.player?.item.playable?.legible.external?.external.available?.isInactive ?? false) || controlsHidden
+            subtitlesTextLabelHidden = (props.player?.item.playable?.legible.external?.external.available?.isInactive ?? false)
             
             thumbnailImageViewHidden = props.player?.item.playable?.thumbnail?.url == nil || controlsHidden
             

--- a/PlayerControls/sources/ContentControlsViewController.swift
+++ b/PlayerControls/sources/ContentControlsViewController.swift
@@ -25,6 +25,7 @@ open class ContentControlsViewController: UIViewController {
         public struct Player: Codable {
             public var playlist: Playlist?
             public var item: Item = .nonplayable("")
+            public var animationsEnabled: Bool = false
             
             public init() {}
         }

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -184,8 +184,12 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             bottomItemsVisibleConstraint.isActive = false
             bottomItemsInvisibleConstraint.isActive = true
             afterSlideAnimation {
-                self.bottomItemsView.subviews.forEach { $0.isHidden = true }
                 self.bottomItemsView.isHidden = true
+                self.pipButton.isHidden = self.uiProps.pipButtonHidden
+                self.airPlayView.isHidden = self.uiProps.airplayButtonHidden
+                self.settingsButton.isHidden = self.uiProps.settingsButtonHidden
+                self.videoTitleLabel.isHidden = self.uiProps.videoTitleLabelHidden
+                
                 self.pipButton.isEnabled = self.uiProps.pipButtonEnabled
                 self.settingsButton.isEnabled = self.uiProps.settingsButtonEnabled
                 self.videoTitleLabel.text = self.uiProps.videoTitleLabelText
@@ -198,14 +202,14 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             }
         case false:
             bottomItemsView.isHidden = false
-            pipButton.isEnabled = uiProps.pipButtonEnabled
-            settingsButton.isEnabled = uiProps.settingsButtonEnabled
-            videoTitleLabel.text = uiProps.videoTitleLabelText
-            
             pipButton.isHidden = uiProps.pipButtonHidden
             airPlayView.isHidden = uiProps.airplayButtonHidden
             settingsButton.isHidden = uiProps.settingsButtonHidden
             videoTitleLabel.isHidden = uiProps.videoTitleLabelHidden
+            
+            pipButton.isEnabled = uiProps.pipButtonEnabled
+            settingsButton.isEnabled = uiProps.settingsButtonEnabled
+            videoTitleLabel.text = uiProps.videoTitleLabelText
             
             airplayPipTrailingConstrains.isActive = !uiProps.pipButtonHidden
             airplayEdgeTrailingConstrains.isActive = uiProps.pipButtonHidden
@@ -284,24 +288,23 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         
         switch uiProps.sideBarViewHidden {
         case true:
-            if !isApperared {
-                sideBarSeekerConstraint.isActive = false
-                sideBarVisibleConstraint.isActive = false
-                sideBarInvisibleConstraint.isActive = true
-                sideBarBottomConstraint.constant =  view.frame.height - sideBarView.frame.height
-                sideBarBottomConstraint.isActive = true
-            }
+            sideBarVisibleConstraint.isActive = false
+            sideBarInvisibleConstraint.isActive = true
+            
+            sideBarBottomConstraint.isActive = true
+            //sideBarSeekerConstraint.isActive = false
+            sideBarBottomConstraint.constant =  view.frame.height - sideBarView.frame.height
+            
             afterSlideAnimation {
                 self.sideBarView.isHidden = true
             }
         case false:
             self.sideBarView.isHidden = false
-            if !isApperared {
-                sideBarInvisibleConstraint.isActive = false
-                sideBarBottomConstraint.isActive = false
-                sideBarVisibleConstraint.isActive = true
-                sideBarSeekerConstraint.isActive = true
-            }
+            sideBarVisibleConstraint.isActive = true
+            sideBarInvisibleConstraint.isActive = false
+
+            sideBarBottomConstraint.isActive = false
+            //sideBarSeekerConstraint.isActive = true
         }
         
         switch  uiProps.seekerViewHidden {
@@ -378,7 +381,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         isLoading = uiProps.loading
         
         bottomItemsSeekerConstraint.constant = {
-            let constraint: CGFloat = uiProps.botoomItemsHidden ? 10 : 1.5
+            let constraint: CGFloat = uiProps.botoomItemsHidden ? 30 : 1.5
             return .init(traitCollection.userInterfaceIdiom == .pad ? constraint : 1.5)
         }()
         
@@ -425,7 +428,23 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             ccTextLabel.alpha = 1
         }
         
-        //ccTextLabel.isHidden = uiProps.subtitlesTextLabelHidden
+        switch uiProps.errorLabelHidden {
+        case true:
+            errorLabel.alpha = 0
+            afterFadeAnimation {
+                self.errorLabel.isHidden = false
+                self.errorLabel.text = self.uiProps.errorLabelText
+            }
+        case false:
+            errorLabel.isHidden = false
+            errorLabel.text = uiProps.errorLabelText
+            errorLabel.alpha = 1
+        }
+        
+        liveIndicationView.isHidden = uiProps.liveIndicationViewIsHidden
+        liveDotLabel.textColor = uiProps.liveDotColor ?? liveDotLabel.textColor ?? view.tintColor
+        
+        airplayActiveLabel.isHidden = uiProps.airplayActiveLabelHidden
         ccTextLabel.text = uiProps.subtitlesTextLabelText
 
         visibleControlsSubtitlesConstraint.constant = {
@@ -470,13 +489,6 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             thumbnailImageView.image = image
         }
         
-        errorLabel.isHidden = uiProps.errorLabelHidden
-        errorLabel.text = uiProps.errorLabelText
-        
-        liveIndicationView.isHidden = uiProps.liveIndicationViewIsHidden
-        liveDotLabel.textColor = uiProps.liveDotColor ?? liveDotLabel.textColor ?? view.tintColor
-        
-        airplayActiveLabel.isHidden = uiProps.airplayActiveLabelHidden
         airPlayView.props = AirPlayView.Props(
             icons: AirPlayView.Props.Icons(
                 normal: UIImage.init(named: "icon-airplay", in: Bundle(for: AirPlayView.self), compatibleWith: nil)!,

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -55,7 +55,6 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     @IBOutlet private var liveDotLabel: UILabel!
     
     @IBOutlet private var visibleControlsSubtitlesConstraint: NSLayoutConstraint!
-    @IBOutlet private var bottomSeekBarConstraint: NSLayoutConstraint!
     @IBOutlet private var compassBodyBelowLiveTopConstraint: NSLayoutConstraint!
     @IBOutlet private var compassBodyNoLiveTopConstraint: NSLayoutConstraint!
     @IBOutlet private var airplayPipTrailingConstrains: NSLayoutConstraint!
@@ -172,14 +171,9 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             errorLabel.layer.add(animationOpacity, forKey: "opacity")
             liveIndicationView.layer.add(animationOpacity, forKey: "opacity")
             airplayActiveLabel.layer.add(animationOpacity, forKey: "opacity")
-        } else {
-            defer {
-                afterSlideAnimationActions.forEach{$0()}
-                afterFadeAnimationActions.forEach{$0()}
-            }
         }
         
-        switch uiProps.botoomItemsHidden {
+        switch uiProps.bottomItemsHidden {
         case true:
             bottomItemsVisibleConstraint.isActive = false
             bottomItemsInvisibleConstraint.isActive = true
@@ -292,7 +286,6 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             sideBarInvisibleConstraint.isActive = true
             
             sideBarBottomConstraint.isActive = true
-            //sideBarSeekerConstraint.isActive = false
             sideBarBottomConstraint.constant =  view.frame.height - sideBarView.frame.height
             
             afterSlideAnimation {
@@ -304,18 +297,15 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             sideBarInvisibleConstraint.isActive = false
 
             sideBarBottomConstraint.isActive = false
-            //sideBarSeekerConstraint.isActive = true
         }
         
         switch  uiProps.seekerViewHidden {
         case true:
-            if uiProps.botoomItemsHidden {
-                print("both hidden")
+            if uiProps.bottomItemsHidden {
                 bottomItemsVisibleConstraint.isActive = false
                 bottomItemsInvisibleConstraint.isActive = false
                 bottomItemsAndSeekerAnimatedConstraint.isActive = true
             } else {
-                print("fade seeker hide")
                 bottomItemsAndSeekerAnimatedConstraint.isActive = false
                 seekerView.alpha = 0
                 durationTextLabel.alpha = 0
@@ -328,6 +318,9 @@ public final class DefaultControlsViewController: ContentControlsViewController 
                 self.seekerView.updateCurrentTime(text: self.uiProps.seekerViewCurrentTimeText)
                 self.seekerView.height = self.traitCollection.userInterfaceIdiom == .pad ? 46 : 38
                 self.seekerView.accessibilityLabel = self.uiProps.seekerViewAccessibilityLabel
+                self.durationTextLabel.isHidden = true
+                self.durationTextLabel.text = self.uiProps.durationTextLabelText
+                self.durationTextLabel.accessibilityLabel = self.uiProps.durationTextLabelAccessibilityLabel
             }
             
         case false:
@@ -339,14 +332,16 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             seekerView.alpha = 1
             durationTextLabel.alpha = 1
             durationTextLabel.isHidden = false
-            if uiProps.botoomItemsHidden {
-                print("onlyBottom items hidden")
+            durationTextLabel.text = uiProps.durationTextLabelText
+            durationTextLabel.accessibilityLabel = uiProps.durationTextLabelAccessibilityLabel
+            
+            
+            if uiProps.bottomItemsHidden {
                 self.seekerView.isHidden = false
                 bottomItemsVisibleConstraint.isActive = false
                 bottomItemsInvisibleConstraint.isActive = true
                 bottomItemsAndSeekerAnimatedConstraint.isActive = false
             } else  {
-                print("nothing hidden")
                 self.seekerView.isHidden = false
                 bottomItemsVisibleConstraint.isActive = true
                 bottomItemsInvisibleConstraint.isActive = false
@@ -381,12 +376,12 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         isLoading = uiProps.loading
         
         bottomItemsSeekerConstraint.constant = {
-            let constraint: CGFloat = uiProps.botoomItemsHidden ? 30 : 1.5
+            let constraint: CGFloat = uiProps.bottomItemsHidden ? 10 : 1.5
             return .init(traitCollection.userInterfaceIdiom == .pad ? constraint : 1.5)
         }()
         
         bottomItemsHeightConstraint.constant = {
-            let constraint: CGFloat = uiProps.botoomItemsHidden ? 62 : 58.5
+            let constraint: CGFloat = uiProps.bottomItemsHidden ? 62 : 58.5
             return .init(traitCollection.userInterfaceIdiom == .pad ? constraint : 51.5)
         }()
         
@@ -413,9 +408,6 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         }
         compasDirectionView.transform = uiProps.compasDirectionViewTransform
         cameraPanGestureRecognizer.isEnabled = uiProps.cameraPanGestureIsEnabled
-        
-        durationTextLabel.text = uiProps.durationTextLabelText
-        durationTextLabel.accessibilityLabel = uiProps.durationTextLabelAccessibilityLabel
         
         switch uiProps.subtitlesTextLabelHidden {
         case true:
@@ -449,9 +441,9 @@ public final class DefaultControlsViewController: ContentControlsViewController 
 
         visibleControlsSubtitlesConstraint.constant = {
             let constant = traitCollection.userInterfaceIdiom == .pad ? 130 : 110
-            var distance = uiProps.botoomItemsHidden && !uiProps.seekerViewHidden ? 45 : 30
+            var distance = uiProps.bottomItemsHidden && !uiProps.seekerViewHidden ? 45 : 30
             
-            return .init(uiProps.controlsViewHidden || uiProps.botoomItemsHidden ? distance : constant)
+            return .init(uiProps.controlsViewHidden || uiProps.bottomItemsHidden ? distance : constant)
         }()
         
         thumbnailImageView.isHidden = uiProps.thumbnailImageViewHidden
@@ -495,6 +487,10 @@ public final class DefaultControlsViewController: ContentControlsViewController 
                 selected: UIImage.init(named: "icon-airplay-active", in: Bundle(for: AirPlayView.self), compatibleWith: nil)!,
                 highlighted: UIImage.init(named: "icon-airplay-active", in: Bundle(for: AirPlayView.self), compatibleWith: nil)!)
         )
+        if !animationsEnabled {
+            afterSlideAnimationActions.forEach{$0()}
+            afterFadeAnimationActions.forEach{$0()}
+        }
     }
     
     //swiftlint:enable function_body_length

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -109,7 +109,8 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     }
     
     var task: URLSessionDataTask?
-    var animationsEnabled: Bool = true
+    var animationsEnabled: Bool = false
+    var animationsDuration: CFTimeInterval = 0.4
     
     var uiProps: UIProps = UIProps(props: .noPlayer, controlsViewVisible: false)
     //swiftlint:disable function_body_length
@@ -136,14 +137,14 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         if animationsEnabled {
             
             let animationPosition = CABasicAnimation(keyPath: "position")
-            animationPosition.duration = 0.4
+            animationPosition.duration = animationsDuration
             animationPosition.delegate = AnimationDelegate(didStop: { _, completed in
                 guard completed else { return }
                 afterSlideAnimationActions.forEach{$0()}
             })
             
             let animationOpacity = CABasicAnimation(keyPath: "opacity")
-            animationOpacity.duration = 0.4
+            animationOpacity.duration = animationsDuration
             animationOpacity.delegate = AnimationDelegate(didStop: { _, completed in
                 guard completed else { return }
                 afterFadeAnimationActions.forEach{$0()}

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -146,6 +146,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             
             sideBarView.layer.add(animationPosition, forKey: "position")
             seekerView.layer.add(animationPosition, forKey: "position")
+            durationTextLabel.layer.add(animationPosition, forKey: "position")
             bottomItemsView.layer.add(animationPosition, forKey: "position")
             ccTextLabel.layer.add(animationPosition, forKey: "position")
             
@@ -188,8 +189,12 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             bottomItemsVisibleConstraint.isActive = false
             bottomItemsInvisibleConstraint.isActive = true
             afterSlideAnimation {
-                self.bottomItemsView.isHidden = true
                 self.bottomItemsView.subviews.forEach { $0.isHidden = true }
+                self.bottomItemsView.isHidden = true
+                self.pipButton.isEnabled = self.uiProps.pipButtonEnabled
+                self.settingsButton.isEnabled = self.uiProps.settingsButtonEnabled
+                self.videoTitleLabel.text = self.uiProps.videoTitleLabelText
+                
                 self.airplayPipTrailingConstrains.isActive = !self.uiProps.pipButtonHidden
                 self.airplayEdgeTrailingConstrains.isActive = self.uiProps.pipButtonHidden
                 self.subtitlesAirplayTrailingConstrains.isActive = !self.uiProps.airplayButtonHidden
@@ -197,8 +202,12 @@ public final class DefaultControlsViewController: ContentControlsViewController 
                 self.subtitlesPipTrailingConstrains.isActive = self.uiProps.airplayButtonHidden
             }
         case false:
-            self.bottomItemsView.isHidden = false
-            self.bottomItemsView.subviews.forEach { $0.isHidden = false }
+            bottomItemsView.subviews.forEach { $0.isHidden = false }
+            bottomItemsView.isHidden = false
+            pipButton.isEnabled = uiProps.pipButtonEnabled
+            settingsButton.isEnabled = uiProps.settingsButtonEnabled
+            videoTitleLabel.text = uiProps.videoTitleLabelText
+            
             airplayPipTrailingConstrains.isActive = !uiProps.pipButtonHidden
             airplayEdgeTrailingConstrains.isActive = uiProps.pipButtonHidden
             subtitlesAirplayTrailingConstrains.isActive = !uiProps.airplayButtonHidden
@@ -212,7 +221,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         case true:
             seekForwardButton.alpha = 0
             afterFadeAnimation {
-                self.retryButton.isHidden = true
+                self.seekForwardButton.isHidden = true
             }
         case false:
             seekForwardButton.isHidden = false
@@ -232,9 +241,9 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         
         switch uiProps.replayButtonHidden {
         case true:
-            retryButton.alpha = 0
+            replayButton.alpha = 0
             afterFadeAnimation {
-                self.retryButton.isHidden = true
+                self.replayButton.isHidden = true
             }
         case false:
             retryButton.isHidden = false
@@ -290,30 +299,37 @@ public final class DefaultControlsViewController: ContentControlsViewController 
                 self.seekerView.isHidden = true
                 self.seekerView.progress = self.uiProps.seekerViewProgress
                 self.seekerView.buffered = self.uiProps.seekerViewBuffered
+                self.seekerView.updateCurrentTime(text: self.uiProps.seekerViewCurrentTimeText)
+                self.seekerView.height = self.traitCollection.userInterfaceIdiom == .pad ? 46 : 38
+                self.seekerView.accessibilityLabel = self.uiProps.seekerViewAccessibilityLabel
+                
             }
         case false:
-            self.seekerView.progress = self.uiProps.seekerViewProgress
-            self.seekerView.buffered = self.uiProps.seekerViewBuffered
+            seekerView.updateCurrentTime(text: uiProps.seekerViewCurrentTimeText)
+            seekerView.progress = uiProps.seekerViewProgress
+            seekerView.buffered = uiProps.seekerViewBuffered
+            seekerView.height = traitCollection.userInterfaceIdiom == .pad ? 46 : 38
+            seekerView.accessibilityLabel = uiProps.seekerViewAccessibilityLabel
             if uiProps.bottomItemsHidden {
                 print("onlyBottom items hidden")
                 self.seekerView.isHidden = false
                 bottomItemsVisibleConstraint.isActive = false
                 bottomItemsInvisibleConstraint.isActive = true
                 bottomItemsAndSeekerAnimatedConstraint.isActive = false
-            } else if (!uiProps.bottomItemsHidden && !allButtonsAndTitleAreHidden) {
-                print("fade seeker appear")
-                seekerView.performFadingAnimation(inHiddenState: uiProps.seekerViewHidden)
-                durationTextLabel.performFadingAnimation(inHiddenState: uiProps.durationTextHidden)
             } else {
-                print("nothing hidden")
-                self.seekerView.isHidden = false
-                bottomItemsVisibleConstraint.isActive = true
-                bottomItemsInvisibleConstraint.isActive = false
-                bottomItemsAndSeekerAnimatedConstraint.isActive = false
+                if (!allButtonsAndTitleAreHidden && seekerView.isHidden) {
+                    print("fade seeker appear")
+                    seekerView.performFadingAnimation(inHiddenState: uiProps.seekerViewHidden)
+                    durationTextLabel.performFadingAnimation(inHiddenState: uiProps.durationTextHidden)
+                } else {
+                    print("nothing hidden")
+                    self.seekerView.isHidden = false
+                    bottomItemsVisibleConstraint.isActive = true
+                    bottomItemsInvisibleConstraint.isActive = false
+                    bottomItemsAndSeekerAnimatedConstraint.isActive = false
+                }
             }
-            
         }
-        seekerView.updateCurrentTime(text: uiProps.seekerViewCurrentTimeText)
         
         switch uiProps.nextButtonHidden {
         case true:
@@ -340,59 +356,26 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         prevButton.isEnabled = uiProps.prevButtonEnabled
         
         
-        shadowView.isHidden = uiProps.controlsViewHidden
         isLoading = uiProps.loading
-        
-        playButton.isHidden = uiProps.playButtonHidden
-        pauseButton.isHidden = uiProps.pauseButtonHidden
-        replayButton.isHidden = uiProps.replayButtonHidden
-        
-        nextButton.isHidden = uiProps.nextButtonHidden
-        nextButton.isEnabled = uiProps.nextButtonEnabled
-        prevButton.isHidden = uiProps.prevButtonHidden
-        prevButton.isEnabled = uiProps.prevButtonEnabled
-        
-        //seekerView.isHidden = uiProps.seekerViewHidden
-        seekerView.updateCurrentTime(text: uiProps.seekerViewCurrentTimeText)
-        seekerView.progress = uiProps.seekerViewProgress
-        seekerView.buffered = uiProps.seekerViewBuffered
-        seekerView.height = traitCollection.userInterfaceIdiom == .pad ? 46 : 38
-        seekerView.accessibilityLabel = uiProps.seekerViewAccessibilityLabel
         
 //        bottomSeekBarConstraint.constant = {
 //            let constant = traitCollection.userInterfaceIdiom == .pad ? 60 : 53
 //            return .init(uiProps.seekbarPositionedAtBottom ? 10 : constant)
 //        }()
         
-        seekBackButton.isHidden = uiProps.seekBackButtonHidden
-        seekForwardButton.isHidden = uiProps.seekForwardButtonHidden
         
-        sideBarView.isHidden = uiProps.sideBarViewHidden
-        
-        compasBodyView.isHidden = uiProps.compasBodyViewHidden
-        compasDirectionView.isHidden = uiProps.compasDirectionViewHidden
         compasDirectionView.transform = uiProps.compasDirectionViewTransform
         cameraPanGestureRecognizer.isEnabled = uiProps.cameraPanGestureIsEnabled
-
-        videoTitleLabel.isHidden = uiProps.videoTitleLabelHidden
-        videoTitleLabel.text = uiProps.videoTitleLabelText
         
         durationTextLabel.text = uiProps.durationTextLabelText
-        //durationTextLabel.isHidden = uiProps.durationTextHidden
         durationTextLabel.accessibilityLabel = uiProps.durationTextLabelAccessibilityLabel
         
-        ccTextLabel.isHidden = uiProps.subtitlesTextLabelHidden
         ccTextLabel.text = uiProps.subtitlesTextLabelText
 
         visibleControlsSubtitlesConstraint.constant = {
             let constant = traitCollection.userInterfaceIdiom == .pad ? 130 : 110
             return .init(uiProps.controlsViewHidden ? 30 : constant)
         }()
-        airplayPipTrailingConstrains.isActive = !uiProps.pipButtonHidden
-        airplayEdgeTrailingConstrains.isActive = uiProps.pipButtonHidden
-        subtitlesAirplayTrailingConstrains.isActive = !uiProps.airplayButtonHidden 
-        subtitlesEdgeTrailingConstrains.isActive = uiProps.airplayButtonHidden && uiProps.pipButtonHidden
-        subtitlesPipTrailingConstrains.isActive = uiProps.airplayButtonHidden
         
         thumbnailImageView.isHidden = uiProps.thumbnailImageViewHidden
         
@@ -433,10 +416,6 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         errorLabel.isHidden = uiProps.errorLabelHidden
         errorLabel.text = uiProps.errorLabelText
         
-        pipButton.isEnabled = uiProps.pipButtonEnabled
-        
-        settingsButton.isEnabled = uiProps.settingsButtonEnabled
-        
         liveIndicationView.isHidden = uiProps.liveIndicationViewIsHidden
         liveDotLabel.textColor = uiProps.liveDotColor ?? liveDotLabel.textColor ?? view.tintColor
         
@@ -447,17 +426,6 @@ public final class DefaultControlsViewController: ContentControlsViewController 
                 selected: UIImage.init(named: "icon-airplay-active", in: Bundle(for: AirPlayView.self), compatibleWith: nil)!,
                 highlighted: UIImage.init(named: "icon-airplay-active", in: Bundle(for: AirPlayView.self), compatibleWith: nil)!)
         )
-    }
-    
-    func setConstraints() {
-        
-        //what is needed: 1) seeker new state, bottomItems new and old state in visible and invisible
-        
-        //bottom items go down && seeker follows
-        //bottom items go up && seeker follows
-        //seeker and bottom items go down
-        //seeker and bottom items go up
-        //seeker fades when bottom items are and will not be hidden
     }
     
     //swiftlint:enable function_body_length

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -64,6 +64,10 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     @IBOutlet private var subtitlesEdgeTrailingConstrains: NSLayoutConstraint!
     @IBOutlet private var subtitlesPipTrailingConstrains: NSLayoutConstraint!
     
+    @IBOutlet private var bottomItemsAndSeekerAnimatedConstraint: NSLayoutConstraint!
+    @IBOutlet private var bottomItemsVisibleConstraint: NSLayoutConstraint!
+    @IBOutlet private var bottomItemsInvisibleConstraint: NSLayoutConstraint!
+    
     public var sidebarProps: SideBarView.Props = [] {
         didSet {
             sideBarView.props = sidebarProps.map { [weak self] in
@@ -92,6 +96,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     }
     
     var task: URLSessionDataTask?
+    var animationsEnabled: Bool = true
     
     var uiProps: UIProps = UIProps(props: .noPlayer, controlsViewVisible: false)
     //swiftlint:disable function_body_length
@@ -103,7 +108,18 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         uiProps = UIProps(props: props,
                           controlsViewVisible: controlsViewVisible)
         
-        controlsView.isHidden = uiProps.controlsViewHidden
+        if animationsEnabled {
+            let animation = CABasicAnimation(keyPath: "position")
+            animation.duration = 0.4
+            animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseOut)
+            
+            seekerView.layer.add(animation, forKey: "position")
+            durationTextLabel.layer.add(animation, forKey: "position")
+            bottomItemsView.layer.add(animation, forKey: "position")
+            
+        }
+        
+        shadowView.isHidden = uiProps.controlsViewHidden
         isLoading = uiProps.loading
         
         playButton.isHidden = uiProps.playButtonHidden
@@ -115,17 +131,17 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         prevButton.isHidden = uiProps.prevButtonHidden
         prevButton.isEnabled = uiProps.prevButtonEnabled
         
-        seekerView.isHidden = uiProps.seekerViewHidden
+        //seekerView.isHidden = uiProps.seekerViewHidden
         seekerView.updateCurrentTime(text: uiProps.seekerViewCurrentTimeText)
         seekerView.progress = uiProps.seekerViewProgress
         seekerView.buffered = uiProps.seekerViewBuffered
         seekerView.height = traitCollection.userInterfaceIdiom == .pad ? 46 : 38
         seekerView.accessibilityLabel = uiProps.seekerViewAccessibilityLabel
         
-        bottomSeekBarConstraint.constant = {
-            let constant = traitCollection.userInterfaceIdiom == .pad ? 60 : 53
-            return .init(uiProps.seekbarPositionedAtBottom ? 10 : constant)
-        }()
+//        bottomSeekBarConstraint.constant = {
+//            let constant = traitCollection.userInterfaceIdiom == .pad ? 60 : 53
+//            return .init(uiProps.seekbarPositionedAtBottom ? 10 : constant)
+//        }()
         
         seekBackButton.isHidden = uiProps.seekBackButtonHidden
         seekForwardButton.isHidden = uiProps.seekForwardButtonHidden
@@ -141,7 +157,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         videoTitleLabel.text = uiProps.videoTitleLabelText
         
         durationTextLabel.text = uiProps.durationTextLabelText
-        durationTextLabel.isHidden = uiProps.durationTextHidden
+        //durationTextLabel.isHidden = uiProps.durationTextHidden
         durationTextLabel.accessibilityLabel = uiProps.durationTextLabelAccessibilityLabel
         
         ccTextLabel.isHidden = uiProps.subtitlesTextLabelHidden
@@ -213,6 +229,37 @@ public final class DefaultControlsViewController: ContentControlsViewController 
                 highlighted: UIImage.init(named: "icon-airplay-active", in: Bundle(for: AirPlayView.self), compatibleWith: nil)!)
         )
         airPlayView.isHidden = uiProps.airplayButtonHidden
+        
+        let allButotnsAndTitleShouldBeHidden = uiProps.videoTitleLabelHidden && uiProps.settingsButtonHidden && uiProps.pipButtonHidden && uiProps.airplayButtonHidden
+        let atleastOneButtonOrTitleShouldBeVisible = !uiProps.videoTitleLabelHidden || !uiProps.settingsButtonHidden || !uiProps.pipButtonHidden || !uiProps.airplayButtonHidden
+        
+        let allButtonsAndTitleAreHidden = videoTitleLabel.isHidden && settingsButton.isHidden && pipButton.isHidden && airPlayView.isHidden
+        let atleastOneButtonOrTitleIsVisible = !videoTitleLabel.isHidden || !settingsButton.isHidden || !pipButton.isHidden || !airPlayView.isHidden
+        
+        ////ПЕРЕДЕЛАТЬ К ХУЯМ!!!!!!!
+        if (atleastOneButtonOrTitleShouldBeVisible && atleastOneButtonOrTitleIsVisible) {
+            print("fade seeker")
+//            seekerView.performFadingAnimation(inHiddenState: uiProps.seekerViewHidden)
+//            durationTextLabel.performFadingAnimation(inHiddenState: uiProps.durationTextHidden)
+        }
+        if allButotnsAndTitleShouldBeHidden && uiProps.seekerViewHidden {
+            print("both hidden")
+            bottomItemsVisibleConstraint.isActive = false
+            bottomItemsInvisibleConstraint.isActive = false
+            bottomItemsAndSeekerAnimatedConstraint.isActive = true
+        }
+        if atleastOneButtonOrTitleShouldBeVisible && !uiProps.seekerViewHidden {
+            print("nothing hidden")
+            bottomItemsVisibleConstraint.isActive = true
+            bottomItemsInvisibleConstraint.isActive = false
+            bottomItemsAndSeekerAnimatedConstraint.isActive = false
+        }
+        if allButotnsAndTitleShouldBeHidden && !uiProps.seekerViewHidden {
+            print("onlyBottom items hidden")
+            bottomItemsVisibleConstraint.isActive = true
+            bottomItemsInvisibleConstraint.isActive = false
+            bottomItemsAndSeekerAnimatedConstraint.isActive = false
+        }
     }
     
     //swiftlint:enable function_body_length

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -318,12 +318,17 @@ public final class DefaultControlsViewController: ContentControlsViewController 
                 self.seekerView.updateCurrentTime(text: self.uiProps.seekerViewCurrentTimeText)
                 self.seekerView.height = self.traitCollection.userInterfaceIdiom == .pad ? 46 : 38
                 self.seekerView.accessibilityLabel = self.uiProps.seekerViewAccessibilityLabel
+                self.durationTextLabel.layer.removeAllAnimations()
                 self.durationTextLabel.isHidden = true
                 self.durationTextLabel.text = self.uiProps.durationTextLabelText
                 self.durationTextLabel.accessibilityLabel = self.uiProps.durationTextLabelAccessibilityLabel
             }
             
         case false:
+            if bottomItemsView.isHidden {
+                seekerView.layer.removeAnimation(forKey: "opacity")
+                durationTextLabel.layer.removeAnimation(forKey: "opacity")
+            }
             seekerView.updateCurrentTime(text: uiProps.seekerViewCurrentTimeText)
             seekerView.progress = uiProps.seekerViewProgress
             seekerView.buffered = uiProps.seekerViewBuffered
@@ -335,13 +340,12 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             durationTextLabel.text = uiProps.durationTextLabelText
             durationTextLabel.accessibilityLabel = uiProps.durationTextLabelAccessibilityLabel
             
-            
             if uiProps.bottomItemsHidden {
                 self.seekerView.isHidden = false
                 bottomItemsVisibleConstraint.isActive = false
                 bottomItemsInvisibleConstraint.isActive = true
                 bottomItemsAndSeekerAnimatedConstraint.isActive = false
-            } else  {
+            } else {
                 self.seekerView.isHidden = false
                 bottomItemsVisibleConstraint.isActive = true
                 bottomItemsInvisibleConstraint.isActive = false
@@ -352,32 +356,33 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         switch uiProps.nextButtonHidden {
         case true:
             nextButton.alpha = 0
+            nextButton.isEnabled = uiProps.nextButtonEnabled
             afterSlideAnimation {
                 self.nextButton.isHidden = true
             }
         case false:
             self.nextButton.isHidden = false
             nextButton.alpha = 1
+            nextButton.isEnabled = uiProps.nextButtonEnabled
         }
-        nextButton.isEnabled = uiProps.nextButtonEnabled
         
         switch uiProps.prevButtonHidden {
         case true:
             prevButton.alpha = 0
             afterFadeAnimation {
                 self.prevButton.isHidden = true
+                self.prevButton.isEnabled = self.uiProps.prevButtonEnabled
             }
         case false:
             self.prevButton.isHidden = false
             prevButton.alpha = 1
+            prevButton.isEnabled = uiProps.prevButtonEnabled
         }
-        prevButton.isEnabled = uiProps.prevButtonEnabled
         
         isLoading = uiProps.loading
         
         bottomItemsSeekerConstraint.constant = {
-            let constraint: CGFloat = uiProps.bottomItemsHidden ? 10 : 1.5
-            return .init(traitCollection.userInterfaceIdiom == .pad ? constraint : 1.5)
+            return .init(uiProps.bottomItemsHidden ? 10 : 1.5)
         }()
         
         bottomItemsHeightConstraint.constant = {
@@ -409,22 +414,21 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         compasDirectionView.transform = uiProps.compasDirectionViewTransform
         cameraPanGestureRecognizer.isEnabled = uiProps.cameraPanGestureIsEnabled
         
-        switch uiProps.subtitlesTextLabelHidden {
-        case true:
-            ccTextLabel.alpha = 0
-            afterFadeAnimation {
-                self.ccTextLabel.isHidden = true
-            }
-        case false:
-            ccTextLabel.isHidden = false
-            ccTextLabel.alpha = 1
-        }
+        ccTextLabel.isHidden = uiProps.subtitlesTextLabelHidden
+        ccTextLabel.text = uiProps.subtitlesTextLabelText
+        
+        visibleControlsSubtitlesConstraint.constant = {
+            let constant = traitCollection.userInterfaceIdiom == .pad ? 130 : 110
+            var distance = uiProps.bottomItemsHidden && !uiProps.seekerViewHidden ? 60 : 30
+            
+            return .init(uiProps.controlsViewHidden || uiProps.bottomItemsHidden ? distance : constant)
+        }()
         
         switch uiProps.errorLabelHidden {
         case true:
             errorLabel.alpha = 0
             afterFadeAnimation {
-                self.errorLabel.isHidden = false
+                self.errorLabel.isHidden = true
                 self.errorLabel.text = self.uiProps.errorLabelText
             }
         case false:
@@ -433,18 +437,29 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             errorLabel.alpha = 1
         }
         
-        liveIndicationView.isHidden = uiProps.liveIndicationViewIsHidden
-        liveDotLabel.textColor = uiProps.liveDotColor ?? liveDotLabel.textColor ?? view.tintColor
+        switch uiProps.liveIndicationViewIsHidden {
+        case true:
+            liveIndicationView.alpha = 0
+            afterFadeAnimation {
+                self.liveIndicationView.isHidden = true
+                self.liveDotLabel.textColor = self.uiProps.liveDotColor ?? self.liveDotLabel.textColor ?? self.view.tintColor
+            }
+        case false:
+            liveIndicationView.isHidden = false
+            liveIndicationView.alpha = 1
+            liveDotLabel.textColor = uiProps.liveDotColor ?? liveDotLabel.textColor ?? view.tintColor
+        }
         
-        airplayActiveLabel.isHidden = uiProps.airplayActiveLabelHidden
-        ccTextLabel.text = uiProps.subtitlesTextLabelText
-
-        visibleControlsSubtitlesConstraint.constant = {
-            let constant = traitCollection.userInterfaceIdiom == .pad ? 130 : 110
-            var distance = uiProps.bottomItemsHidden && !uiProps.seekerViewHidden ? 45 : 30
-            
-            return .init(uiProps.controlsViewHidden || uiProps.bottomItemsHidden ? distance : constant)
-        }()
+        switch uiProps.airplayActiveLabelHidden {
+        case true:
+            airplayActiveLabel.alpha = 0
+            afterFadeAnimation {
+                self.airplayActiveLabel.isHidden = true
+            }
+        case false:
+            airplayActiveLabel.isHidden = false
+            airplayActiveLabel.alpha = 1
+        }
         
         thumbnailImageView.isHidden = uiProps.thumbnailImageViewHidden
         

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -73,6 +73,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     @IBOutlet private var sideBarVisibleConstraint: NSLayoutConstraint!
     @IBOutlet private var sideBarSeekerConstraint: NSLayoutConstraint!
     @IBOutlet private var sideBarBottomConstraint: NSLayoutConstraint!
+    @IBOutlet private var bottomItemsHeightConstraint: NSLayoutConstraint!
     
     public var sidebarProps: SideBarView.Props = [] {
         didSet {
@@ -282,7 +283,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         
         switch uiProps.sideBarViewHidden {
         case true:
-            if isApperared {
+            if !isApperared {
                 sideBarSeekerConstraint.isActive = false
                 sideBarVisibleConstraint.isActive = false
                 sideBarInvisibleConstraint.isActive = true
@@ -294,7 +295,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             }
         case false:
             self.sideBarView.isHidden = false
-            if isApperared {
+            if !isApperared {
                 sideBarInvisibleConstraint.isActive = false
                 sideBarBottomConstraint.isActive = false
                 sideBarVisibleConstraint.isActive = true
@@ -376,9 +377,14 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         isLoading = uiProps.loading
         
         bottomItemsSeekerConstraint.constant = {
-            return .init(traitCollection.userInterfaceIdiom == .pad ? 5 : 1.5)
+            let constraint: CGFloat = uiProps.botoomItemsHidden ? 10 : 1.5
+            return .init(traitCollection.userInterfaceIdiom == .pad ? constraint : 1.5)
         }()
         
+        bottomItemsHeightConstraint.constant = {
+            let constraint: CGFloat = uiProps.botoomItemsHidden ? 62 : 58.5
+            return .init(traitCollection.userInterfaceIdiom == .pad ? constraint : 51.5)
+        }()
         
         switch uiProps.compasBodyViewHidden {
         case true:

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -108,8 +108,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     }
     
     var task: URLSessionDataTask?
-    var animationsEnabled: Bool = false
-    var animationsDuration: CFTimeInterval = 0.4
+    public var animationsDuration: CFTimeInterval = 0.4
     
     var uiProps: UIProps = UIProps(props: .noPlayer, controlsViewVisible: false)
     //swiftlint:disable function_body_length
@@ -133,7 +132,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             afterFadeAnimationActions.append(block)
         }
 
-        if animationsEnabled {
+        if uiProps.animationsEnabled {
             
             let animationPosition = CABasicAnimation(keyPath: "position")
             animationPosition.duration = animationsDuration
@@ -502,7 +501,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
                 selected: UIImage.init(named: "icon-airplay-active", in: Bundle(for: AirPlayView.self), compatibleWith: nil)!,
                 highlighted: UIImage.init(named: "icon-airplay-active", in: Bundle(for: AirPlayView.self), compatibleWith: nil)!)
         )
-        if !animationsEnabled {
+        if !uiProps.animationsEnabled {
             afterSlideAnimationActions.forEach{$0()}
             afterFadeAnimationActions.forEach{$0()}
         }

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -68,6 +68,8 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     @IBOutlet private var bottomItemsVisibleConstraint: NSLayoutConstraint!
     @IBOutlet private var bottomItemsInvisibleConstraint: NSLayoutConstraint!
     
+    //@IBOutlet private var sideBarConstraints: AnimationsConstraint!
+    
     public var sidebarProps: SideBarView.Props = [] {
         didSet {
             sideBarView.props = sidebarProps.map { [weak self] in
@@ -95,6 +97,12 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         }
     }
     
+    var isApperared = false
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        isApperared = true
+    }
+    
     var task: URLSessionDataTask?
     var animationsEnabled: Bool = true
     
@@ -108,16 +116,229 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         uiProps = UIProps(props: props,
                           controlsViewVisible: controlsViewVisible)
         
+        var afterSlideAnimationActions: [() -> ()] = []
+        func afterSlideAnimation(block: @escaping () -> ()) {
+            afterSlideAnimationActions.append(block)
+        }
+        
+        var afterFadeAnimationActions: [() -> ()] = []
+        func afterFadeAnimation(block: @escaping () -> ()) {
+            afterFadeAnimationActions.append(block)
+        }
+        
+        let allButtonsAndTitleAreHidden = (videoTitleLabel.isHidden || videoTitleLabel.text == "") && settingsButton.isHidden && pipButton.isHidden && airPlayView.isHidden
+        
         if animationsEnabled {
-            let animation = CABasicAnimation(keyPath: "position")
-            animation.duration = 0.4
-            animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseOut)
             
-            seekerView.layer.add(animation, forKey: "position")
-            durationTextLabel.layer.add(animation, forKey: "position")
-            bottomItemsView.layer.add(animation, forKey: "position")
+            let animationPosition = CABasicAnimation(keyPath: "position")
+            animationPosition.duration = 0.4
+            animationPosition.delegate = AnimationDelegate(didStop: { _, completed in
+                guard completed else { return }
+                afterSlideAnimationActions.forEach{$0()}
+            })
+            
+            let animationOpacity = CABasicAnimation(keyPath: "opacity")
+            animationOpacity.duration = 0.4
+            animationOpacity.delegate = AnimationDelegate(didStop: { _, completed in
+                guard completed else { return }
+                afterFadeAnimationActions.forEach{$0()}
+            })
+            
+            sideBarView.layer.add(animationPosition, forKey: "position")
+            seekerView.layer.add(animationPosition, forKey: "position")
+            bottomItemsView.layer.add(animationPosition, forKey: "position")
+            ccTextLabel.layer.add(animationPosition, forKey: "position")
+            
+            shadowView.layer.add(animationOpacity, forKey: "opacity")
+            playButton.layer.add(animationOpacity, forKey: "opacity")
+            pauseButton.layer.add(animationOpacity, forKey: "opacity")
+            replayButton.layer.add(animationOpacity, forKey: "opacity")
+            nextButton.layer.add(animationOpacity, forKey: "opacity")
+            prevButton.layer.add(animationOpacity, forKey: "opacity")
+            seekBackButton.layer.add(animationOpacity, forKey: "opacity")
+            seekForwardButton.layer.add(animationOpacity, forKey: "opacity")
+            compasBodyView.layer.add(animationOpacity, forKey: "opacity")
+            compasDirectionView.layer.add(animationOpacity, forKey: "opacity")
+            retryButton.layer.add(animationOpacity, forKey: "opacity")
+            errorLabel.layer.add(animationOpacity, forKey: "opacity")
+            liveIndicationView.layer.add(animationOpacity, forKey: "opacity")
+            airplayActiveLabel.layer.add(animationOpacity, forKey: "opacity")
+        }
+        
+        if !isApperared {
+            shadowView.isHidden = uiProps.controlsViewHidden
+            playButton.isHidden = uiProps.playButtonHidden
+            pauseButton.isHidden = uiProps.pauseButtonHidden
+            replayButton.isHidden = uiProps.replayButtonHidden
+            
+            
+            seekBackButton.isHidden = uiProps.seekBackButtonHidden
+            seekForwardButton.isHidden = uiProps.seekForwardButtonHidden
+            compasBodyView.isHidden = uiProps.compasBodyViewHidden
+            compasDirectionView.isHidden = uiProps.compasDirectionViewHidden
+            retryButton.isHidden = uiProps.retryButtonHidden
+            errorLabel.isHidden = uiProps.errorLabelHidden
+            liveIndicationView.isHidden = uiProps.liveIndicationViewIsHidden
+            airplayActiveLabel.isHidden = uiProps.airplayActiveLabelHidden
+            
+            sideBarView.isHidden = uiProps.sideBarViewHidden
+        }
+        switch uiProps.bottomItemsHidden {
+        case true:
+            bottomItemsVisibleConstraint.isActive = false
+            bottomItemsInvisibleConstraint.isActive = true
+            afterSlideAnimation {
+                self.bottomItemsView.isHidden = true
+                self.bottomItemsView.subviews.forEach { $0.isHidden = true }
+                self.airplayPipTrailingConstrains.isActive = !self.uiProps.pipButtonHidden
+                self.airplayEdgeTrailingConstrains.isActive = self.uiProps.pipButtonHidden
+                self.subtitlesAirplayTrailingConstrains.isActive = !self.uiProps.airplayButtonHidden
+                self.subtitlesEdgeTrailingConstrains.isActive = self.uiProps.airplayButtonHidden && self.uiProps.pipButtonHidden
+                self.subtitlesPipTrailingConstrains.isActive = self.uiProps.airplayButtonHidden
+            }
+        case false:
+            self.bottomItemsView.isHidden = false
+            self.bottomItemsView.subviews.forEach { $0.isHidden = false }
+            airplayPipTrailingConstrains.isActive = !uiProps.pipButtonHidden
+            airplayEdgeTrailingConstrains.isActive = uiProps.pipButtonHidden
+            subtitlesAirplayTrailingConstrains.isActive = !uiProps.airplayButtonHidden
+            subtitlesEdgeTrailingConstrains.isActive = uiProps.airplayButtonHidden && uiProps.pipButtonHidden
+            subtitlesPipTrailingConstrains.isActive = uiProps.airplayButtonHidden
+            bottomItemsVisibleConstraint.isActive = true
+            bottomItemsInvisibleConstraint.isActive = false
+        }
+        
+        switch uiProps.seekForwardButtonHidden {
+        case true:
+            seekForwardButton.alpha = 0
+            afterFadeAnimation {
+                self.retryButton.isHidden = true
+            }
+        case false:
+            seekForwardButton.isHidden = false
+            seekForwardButton.alpha = 1
+        }
+        
+        switch uiProps.seekBackButtonHidden {
+        case true:
+            seekBackButton.alpha = 0
+            afterFadeAnimation {
+                self.seekBackButton.isHidden = true
+            }
+        case false:
+            seekBackButton.isHidden = false
+            seekBackButton.alpha = 1
+        }
+        
+        switch uiProps.replayButtonHidden {
+        case true:
+            retryButton.alpha = 0
+            afterFadeAnimation {
+                self.retryButton.isHidden = true
+            }
+        case false:
+            retryButton.isHidden = false
+            retryButton.alpha = 1
+        }
+        
+        switch uiProps.pauseButtonHidden {
+        case true:
+            pauseButton.alpha = 0
+            afterFadeAnimation {
+                self.pauseButton.isHidden = true
+            }
+        case false:
+            pauseButton.isHidden = false
+            pauseButton.alpha = 1
+        }
+        
+        switch uiProps.playButtonHidden {
+        case true:
+            playButton.alpha = 0
+            afterFadeAnimation {
+                self.playButton.isHidden = true
+            }
+        case false:
+            playButton.isHidden = false
+            playButton.alpha = 1
+        }
+        
+        switch uiProps.sideBarViewHidden {
+        case true:
+//            sideBarConstraints.toggleToInVisible()
+            afterSlideAnimation {
+                self.sideBarView.isHidden = true
+            }
+        case false:
+            self.sideBarView.isHidden = false
+//            sideBarConstraints.toggleToVisible()
+        }
+        
+        switch  uiProps.seekerViewHidden {
+        case true:
+            if uiProps.bottomItemsHidden {
+                print("both hidden")
+                bottomItemsVisibleConstraint.isActive = false
+                bottomItemsInvisibleConstraint.isActive = false
+                bottomItemsAndSeekerAnimatedConstraint.isActive = true
+            } else {
+                print("fade seeker hide")
+                seekerView.performFadingAnimation(inHiddenState: uiProps.seekerViewHidden)
+                durationTextLabel.performFadingAnimation(inHiddenState: uiProps.durationTextHidden)
+            }
+            afterSlideAnimation {
+                self.seekerView.isHidden = true
+                self.seekerView.progress = self.uiProps.seekerViewProgress
+                self.seekerView.buffered = self.uiProps.seekerViewBuffered
+            }
+        case false:
+            self.seekerView.progress = self.uiProps.seekerViewProgress
+            self.seekerView.buffered = self.uiProps.seekerViewBuffered
+            if uiProps.bottomItemsHidden {
+                print("onlyBottom items hidden")
+                self.seekerView.isHidden = false
+                bottomItemsVisibleConstraint.isActive = false
+                bottomItemsInvisibleConstraint.isActive = true
+                bottomItemsAndSeekerAnimatedConstraint.isActive = false
+            } else if (!uiProps.bottomItemsHidden && !allButtonsAndTitleAreHidden) {
+                print("fade seeker appear")
+                seekerView.performFadingAnimation(inHiddenState: uiProps.seekerViewHidden)
+                durationTextLabel.performFadingAnimation(inHiddenState: uiProps.durationTextHidden)
+            } else {
+                print("nothing hidden")
+                self.seekerView.isHidden = false
+                bottomItemsVisibleConstraint.isActive = true
+                bottomItemsInvisibleConstraint.isActive = false
+                bottomItemsAndSeekerAnimatedConstraint.isActive = false
+            }
             
         }
+        seekerView.updateCurrentTime(text: uiProps.seekerViewCurrentTimeText)
+        
+        switch uiProps.nextButtonHidden {
+        case true:
+            nextButton.alpha = 0
+            afterSlideAnimation {
+                self.nextButton.isHidden = true
+            }
+        case false:
+            self.nextButton.isHidden = true
+            nextButton.alpha = 1
+        }
+        nextButton.isEnabled = uiProps.nextButtonEnabled
+        
+        switch uiProps.prevButtonHidden {
+        case true:
+            prevButton.alpha = 0
+            afterFadeAnimation {
+                self.prevButton.isHidden = true
+            }
+        case false:
+            self.prevButton.isHidden = true
+            prevButton.alpha = 1
+        }
+        prevButton.isEnabled = uiProps.prevButtonEnabled
+        
         
         shadowView.isHidden = uiProps.controlsViewHidden
         isLoading = uiProps.loading
@@ -212,10 +433,8 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         errorLabel.isHidden = uiProps.errorLabelHidden
         errorLabel.text = uiProps.errorLabelText
         
-        pipButton.isHidden = uiProps.pipButtonHidden
         pipButton.isEnabled = uiProps.pipButtonEnabled
         
-        settingsButton.isHidden = uiProps.settingsButtonHidden
         settingsButton.isEnabled = uiProps.settingsButtonEnabled
         
         liveIndicationView.isHidden = uiProps.liveIndicationViewIsHidden
@@ -228,38 +447,17 @@ public final class DefaultControlsViewController: ContentControlsViewController 
                 selected: UIImage.init(named: "icon-airplay-active", in: Bundle(for: AirPlayView.self), compatibleWith: nil)!,
                 highlighted: UIImage.init(named: "icon-airplay-active", in: Bundle(for: AirPlayView.self), compatibleWith: nil)!)
         )
-        airPlayView.isHidden = uiProps.airplayButtonHidden
+    }
+    
+    func setConstraints() {
         
-        let allButotnsAndTitleShouldBeHidden = uiProps.videoTitleLabelHidden && uiProps.settingsButtonHidden && uiProps.pipButtonHidden && uiProps.airplayButtonHidden
-        let atleastOneButtonOrTitleShouldBeVisible = !uiProps.videoTitleLabelHidden || !uiProps.settingsButtonHidden || !uiProps.pipButtonHidden || !uiProps.airplayButtonHidden
+        //what is needed: 1) seeker new state, bottomItems new and old state in visible and invisible
         
-        let allButtonsAndTitleAreHidden = videoTitleLabel.isHidden && settingsButton.isHidden && pipButton.isHidden && airPlayView.isHidden
-        let atleastOneButtonOrTitleIsVisible = !videoTitleLabel.isHidden || !settingsButton.isHidden || !pipButton.isHidden || !airPlayView.isHidden
-        
-        ////ПЕРЕДЕЛАТЬ К ХУЯМ!!!!!!!
-        if (atleastOneButtonOrTitleShouldBeVisible && atleastOneButtonOrTitleIsVisible) {
-            print("fade seeker")
-//            seekerView.performFadingAnimation(inHiddenState: uiProps.seekerViewHidden)
-//            durationTextLabel.performFadingAnimation(inHiddenState: uiProps.durationTextHidden)
-        }
-        if allButotnsAndTitleShouldBeHidden && uiProps.seekerViewHidden {
-            print("both hidden")
-            bottomItemsVisibleConstraint.isActive = false
-            bottomItemsInvisibleConstraint.isActive = false
-            bottomItemsAndSeekerAnimatedConstraint.isActive = true
-        }
-        if atleastOneButtonOrTitleShouldBeVisible && !uiProps.seekerViewHidden {
-            print("nothing hidden")
-            bottomItemsVisibleConstraint.isActive = true
-            bottomItemsInvisibleConstraint.isActive = false
-            bottomItemsAndSeekerAnimatedConstraint.isActive = false
-        }
-        if allButotnsAndTitleShouldBeHidden && !uiProps.seekerViewHidden {
-            print("onlyBottom items hidden")
-            bottomItemsVisibleConstraint.isActive = true
-            bottomItemsInvisibleConstraint.isActive = false
-            bottomItemsAndSeekerAnimatedConstraint.isActive = false
-        }
+        //bottom items go down && seeker follows
+        //bottom items go up && seeker follows
+        //seeker and bottom items go down
+        //seeker and bottom items go up
+        //seeker fades when bottom items are and will not be hidden
     }
     
     //swiftlint:enable function_body_length

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -50,6 +50,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     @IBOutlet private var settingsButton: UIButton!
     @IBOutlet private var airPlayView: AirPlayView!
     
+    @IBOutlet private var bottomItemsView: UIView!
     @IBOutlet private var liveIndicationView: UIView!
     @IBOutlet private var liveDotLabel: UILabel!
     

--- a/PlayerControls/sources/Utils.swift
+++ b/PlayerControls/sources/Utils.swift
@@ -39,12 +39,4 @@ extension UIView {
                        in: Bundle(for: type(of: self)),
                        compatibleWith: traitCollection)!
     }
-    func performFadingAnimation(inHiddenState state: Bool) {
-        let animation = CATransition()
-        animation.type = kCATransitionFade
-        animation.duration = 0.4
-        animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseOut)
-        layer.add(animation, forKey: "hidden")
-        isHidden = state
-    }
 }

--- a/PlayerControls/sources/Utils.swift
+++ b/PlayerControls/sources/Utils.swift
@@ -39,4 +39,12 @@ extension UIView {
                        in: Bundle(for: type(of: self)),
                        compatibleWith: traitCollection)!
     }
+    func performFadingAnimation(inHiddenState state: Bool) {
+        let animation = CATransition()
+        animation.type = kCATransitionFade
+        animation.duration = 0.4
+        animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseOut)
+        layer.add(animation, forKey: "hidden")
+        isHidden = state
+    }
 }

--- a/SnapshotTests/DefaulController/CaseWithThumbnail.swift
+++ b/SnapshotTests/DefaulController/CaseWithThumbnail.swift
@@ -3,7 +3,6 @@
 import SnappyShrimp
 @testable import PlayerControls
 
-
 class CaseWithThumbnail: SnapshotTest{
     
     var controller: DefaultControlsViewController {


### PR DESCRIPTION
# Player Controls Animation
## Development
We’ve implemented animations for player controls instead of simple hiding. We’ve decided to use `CABasicAnimation` instead of `UIView.animate`. 
First of all, because we want to use implicit animation. It means that we simply add animation to each view layer and then when position or opacity is changed, these changes are performed animated. 
The reason for choosing that way is that our position animation is performed by changing constraints. So to animate these changes using `UIView.animate`, we had to call a `layoutIfNeeded` method in its animation block. And it is not what we want to call in `viewWillLayoutSubviews`. And it also makes a mess, because there are a lot of changes that have to be done only after the animation is completed and it looks very confusing, even in a single completion block.
So we’ve created `AnimationDelegate`, that now handles everything that has to be done only when the animation is completed.
## UIProps Changes
We’ve added some changes to `uiProps`. Now that we’re not hiding our controls by hiding entire `controlsView`, each object of `uiProps` is now also watching the `controlsHidden` state. So now, in a case when all controls should be hidden, all elements that should be hidden will have `isHidden` state `true`.

## Animation Types
We have the next list of views and animation types applied to them:
- Fade in/Fade out 
All buttons that located in the middle (play, pause, playlist buttons etc.), `Compass view` and `Live indicator view` and `Shadow view`.
- Slide up/Slide down
Slide down animation is implemented for seekerView and for new `bottomItemsView`, that now contains `settings button`, `pip button`, `airplay button` and `title label`. There is a single case when `seekerView`will appear/disappear with fade. It happens when `bottomItemsView` is visible and we don’t want these views to cross each other.
- Slide aside
 This animation is applied only to `sidebar view` that will slide right or left.
## Preview

### Animation of appearing/disappearing for all controls
<img src="https://user-images.githubusercontent.com/31652265/35800914-1ba64640-0a73-11e8-9d87-2b4ae977b72e.gif" width="400">

### Transition table for seekbar and bottom items
 <head>
  <meta charset="utf-8">
 </head> 
<table style="width:100%">
  <tr>
    <th>From</th>
    <th>To</th>
    <th>Animation Type</th> 
    <th>Gif from UI</th>
  </tr>
  <tr>
    <td>
<img src="https://user-images.githubusercontent.com/32369717/35735543-e37f6a54-082d-11e8-9360-baad786b0411.jpg" width="150">
</td>
    <td><img src="https://user-images.githubusercontent.com/32369717/35736007-43b14bee-082f-11e8-8587-0b50565434a1.jpg" width="150"></td> 
    <td>Slide</td>
    <td><img src="https://user-images.githubusercontent.com/32369717/35742363-df990318-0842-11e8-99ac-0a97e4b2ee30.gif" width="450"></td> 
  </tr>
  <tr>
     <td>
<img src="https://user-images.githubusercontent.com/32369717/35735543-e37f6a54-082d-11e8-9360-baad786b0411.jpg" width="150">
</td>
    <td><img src="https://user-images.githubusercontent.com/32369717/35736163-a58d97dc-082f-11e8-8182-46e8d79358d7.jpg" width="150"></td> 
    <td>Slide</td>
       <td><img src="https://user-images.githubusercontent.com/32369717/35742427-17bbb948-0843-11e8-8031-adc742081b62.gif" width="450"></td> 
  </tr>
<tr>
     <td>
<img src="https://user-images.githubusercontent.com/32369717/35735543-e37f6a54-082d-11e8-9360-baad786b0411.jpg" width="150">
</td>
    <td><img src="https://user-images.githubusercontent.com/32369717/35736301-2d43cb92-0830-11e8-8c0c-46b0dc7285c3.jpg" width="150"></td> 
    <td>Slide</td>
<td><img src="https://user-images.githubusercontent.com/32369717/35742450-2c2fb014-0843-11e8-8524-5241c20ddaba.gif" width="450"></td> 
  </tr>
<tr>
     <td><img src="https://user-images.githubusercontent.com/32369717/35736359-6f12d22a-0830-11e8-89bb-77e218319f29.jpg" width="150">
</td>
    <td><img src="https://user-images.githubusercontent.com/32369717/35736381-7e6269a2-0830-11e8-9bdf-682d646c4757.jpg" width="150"></td> 
    <td>Slide</td>
<td><img src="https://user-images.githubusercontent.com/32369717/35742501-478bfb7e-0843-11e8-922d-15440e165ca1.gif" width="450"></td> 
  </tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/32369717/35736359-6f12d22a-0830-11e8-89bb-77e218319f29.jpg" width="150">
</td>
    <td><img src="https://user-images.githubusercontent.com/32369717/35736482-db2149c4-0830-11e8-8731-0dd1aafe6dc4.jpg" width="150"></td> 
    <td>Fade</td>
   <td><img src="https://user-images.githubusercontent.com/32369717/35742540-656807a0-0843-11e8-90bf-07423c1a6efc.gif" width="450"></td> 
  </tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/32369717/35736482-db2149c4-0830-11e8-8731-0dd1aafe6dc4.jpg" width="150">
</td>
    <td><img src="https://user-images.githubusercontent.com/32369717/35736301-2d43cb92-0830-11e8-8c0c-46b0dc7285c3.jpg" width="150"></td> 
    <td>Fade</td>
<td><img src="https://user-images.githubusercontent.com/32369717/35742572-8aae501e-0843-11e8-9d3e-059eef382672.gif" width="450"></td> 
  </tr>
  </tr>
</table>

## Current issues and future improvements
- Fix for Sidebar when seeker moves down
- Buttons changing each other with slide or fade
- Device rotation bugs