### PR TITLE
Sourcery for codable

### DIFF
--- a/PlayerControls/PlayerControls.xcodeproj/project.pbxproj
+++ b/PlayerControls/PlayerControls.xcodeproj/project.pbxproj
@@ -9,8 +9,9 @@
 /* Begin PBXBuildFile section */
 		06536931202320C100F65305 /* AnimationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06536930202320C100F65305 /* AnimationDelegate.swift */; };
 		0696270D1FD188A50098494A /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0696270C1FD188A50098494A /* Command.swift */; };
-		422017F41FE3D557002E4DE5 /* Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 422017F31FE3D557002E4DE5 /* Codable.swift */; };
+		4222DD61204F0F180008E763 /* Autogeneratable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4222DD60204F0F180008E763 /* Autogeneratable.swift */; };
 		427DA9131FFBA1E700698438 /* Defaultable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 427DA9121FFBA1E700698438 /* Defaultable.swift */; };
+		429BDDCB2034699700DFF55B /* Codable.stencil in Sources */ = {isa = PBXBuildFile; fileRef = 429BDDC920344E4F00DFF55B /* Codable.stencil */; };
 		429C3D341FFBA54200B72272 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429C3D331FFBA54200B72272 /* Color.swift */; };
 		42A7F65A1FEC230D00CE39C0 /* ContentControlsUIProps+Init.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A7F6591FEC230D00CE39C0 /* ContentControlsUIProps+Init.swift */; };
 		50582F6C1E65C64B00B18908 /* ContentControlsUIProps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50582F671E65C64B00B18908 /* ContentControlsUIProps.swift */; };
@@ -74,8 +75,9 @@
 /* Begin PBXFileReference section */
 		06536930202320C100F65305 /* AnimationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationDelegate.swift; sourceTree = "<group>"; };
 		0696270C1FD188A50098494A /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
-		422017F31FE3D557002E4DE5 /* Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Codable.swift; sourceTree = "<group>"; };
+		4222DD60204F0F180008E763 /* Autogeneratable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Autogeneratable.swift; sourceTree = "<group>"; };
 		427DA9121FFBA1E700698438 /* Defaultable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Defaultable.swift; sourceTree = "<group>"; };
+		429BDDC920344E4F00DFF55B /* Codable.stencil */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Codable.stencil; path = templates/Codable.stencil; sourceTree = SOURCE_ROOT; };
 		429C3D331FFBA54200B72272 /* Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		42A7F6571FEC156400CE39C0 /* Defaultable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Defaultable.swift; sourceTree = "<group>"; };
 		42A7F6591FEC230D00CE39C0 /* ContentControlsUIProps+Init.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentControlsUIProps+Init.swift"; sourceTree = "<group>"; };
@@ -291,7 +293,7 @@
 				50582F731E65C79D00B18908 /* Utils.swift */,
 				0696270C1FD188A50098494A /* Command.swift */,
 				50582FB11E65DEF800B18908 /* Recorder.swift */,
-				422017F31FE3D557002E4DE5 /* Codable.swift */,
+				4222DD60204F0F180008E763 /* Autogeneratable.swift */,
 			);
 			name = utils;
 			sourceTree = "<group>";
@@ -338,6 +340,7 @@
 		DAB9AEEA1F542C460050B940 /* templates */ = {
 			isa = PBXGroup;
 			children = (
+				429BDDC920344E4F00DFF55B /* Codable.stencil */,
 				DA73095C1F5FD3AD000A7364 /* EnumPrism.stencil */,
 			);
 			path = templates;
@@ -465,12 +468,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				DA73095D1F5FD3AD000A7364 /* EnumPrism.stencil in Sources */,
+				429BDDCB2034699700DFF55B /* Codable.stencil in Sources */,
 				50582F811E65CA0F00B18908 /* AdVideoControls.swift in Sources */,
 				50582F6E1E65C64B00B18908 /* ContentControlsViewController.swift in Sources */,
 				0696270D1FD188A50098494A /* Command.swift in Sources */,
 				50582F7E1E65C96100B18908 /* SeekGestureRecognizer.swift in Sources */,
 				06536931202320C100F65305 /* AnimationDelegate.swift in Sources */,
-				422017F41FE3D557002E4DE5 /* Codable.swift in Sources */,
+				4222DD61204F0F180008E763 /* Autogeneratable.swift in Sources */,
 				50582F8C1E65CBE600B18908 /* Timer.swift in Sources */,
 				50F471591F5D763500C35AEF /* SettingHeaderView.swift in Sources */,
 				50582F861E65CA5F00B18908 /* TimeFormatter.swift in Sources */,

--- a/PlayerControls/sources/AdVideoControls.swift
+++ b/PlayerControls/sources/AdVideoControls.swift
@@ -77,12 +77,12 @@ public final class AdVideoControls: UIViewController {
         public let isLoading: Bool
         public let airplayActiveViewHidden: Bool
         
-        public enum ClickAction: Prism {
+        public enum ClickAction: Prism, AutoCodable {
             case show(Command)
             case hide(Command)
         }
         
-        public enum MainAction: Prism {
+        public enum MainAction: Prism, AutoCodable {
             case play(Command)
             case pause(Command)
         }

--- a/PlayerControls/sources/Autogeneratable.swift
+++ b/PlayerControls/sources/Autogeneratable.swift
@@ -1,0 +1,24 @@
+//
+//  Autogeneratable.swift
+//  PlayerControls
+//
+//  Created by Andrey Doroshko on 3/6/18.
+//  Copyright © 2018 One by AOL : Publishers. All rights reserved.
+//
+
+import Foundation
+
+public protocol Prism {}
+public protocol AutoCodable {}
+
+extension ContentControlsViewController.Props: Prism, AutoCodable {}
+extension ContentControlsViewController.Props.Item: Prism, AutoCodable {}
+extension ContentControlsViewController.Props.AirPlay: Prism, AutoCodable {}
+extension ContentControlsViewController.Props.External: Prism, AutoCodable {}
+extension ContentControlsViewController.Props.External.State: Prism, AutoCodable {}
+extension ContentControlsViewController.Props.PictureInPictureControl: Prism, AutoCodable {}
+extension ContentControlsViewController.Props.Playback: Prism, AutoCodable {}
+extension ContentControlsViewController.Props.Settings: Prism, AutoCodable {}
+extension ContentControlsViewController.Props.Subtitles: Prism, AutoCodable {}
+extension ContentControlsViewController.Props.Thumbnail: Prism, AutoCodable {}
+

--- a/PlayerControls/sources/ContentControlsViewController.swift
+++ b/PlayerControls/sources/ContentControlsViewController.swift
@@ -3,8 +3,6 @@
 
 import Foundation
 import CoreMedia
-///Generate prism for confirmed enum
-public protocol Prism {}
 /// Base class for implementing custom content
 /// video controls.
 open class ContentControlsViewController: UIViewController {
@@ -17,7 +15,7 @@ open class ContentControlsViewController: UIViewController {
         }
     }
     
-    public enum Props: Prism {
+    public enum Props {
         case noPlayer
         
         case player(Player)
@@ -38,7 +36,7 @@ open class ContentControlsViewController: UIViewController {
             public init() {}
         }
         
-        public enum Item: Prism {
+        public enum Item {
             case playable(Controls)
             case nonplayable(String)
         }
@@ -80,7 +78,7 @@ extension ContentControlsViewController.Props {
         public init() {}
     }
     
-    public enum AirPlay: Prism {
+    public enum AirPlay {
         case hidden
         case enabled
         case active
@@ -94,12 +92,12 @@ extension ContentControlsViewController.Props {
         public init() {}
     }
     
-    public enum External: Prism {
+    public enum External {
         case none
         case unavailable
         case available(state: State)
         
-        public enum State: Prism {
+        public enum State {
             case active(text: String?), loading, inactive, error
         }
     }
@@ -132,13 +130,13 @@ extension ContentControlsViewController.Props {
         public init() {}
     }
     
-    public enum PictureInPictureControl: Prism {
+    public enum PictureInPictureControl {
         case unsupported
         case impossible
         case possible(Command)
     }
     
-    public enum Playback: Prism {
+    public enum Playback {
         case none
         case play(Command)
         case pause(Command)
@@ -171,18 +169,18 @@ extension ContentControlsViewController.Props {
         public init() {}
     }
     
-    public enum Subtitles: Prism {
+    public enum Subtitles {
         case `internal`(MediaGroupControl?)
         case external(external: External, control: MediaGroupControl)
     }
     
-    public enum Settings: Prism {
+    public enum Settings {
         case hidden
         case disabled
         case enabled(Command)
     }
     
-    public enum Thumbnail: Prism {
+    public enum Thumbnail {
         case url(URL) //swiftlint:disable:this type_name
         case image(UIImage)
     }

--- a/PlayerControls/templates/Codable.stencil
+++ b/PlayerControls/templates/Codable.stencil
@@ -1,0 +1,113 @@
+import Foundation
+
+fileprivate enum EnumCodingKeys: String, CodingKey { case `case`, value }
+
+{% macro value enum %}
+public enum Cases: String, Codable {
+{% for case in enum.cases %}
+case {{ case.name }}
+{% endfor %}
+}
+{% endmacro %}
+
+{% macro error enum%}
+{% for case in enum.cases %}
+    {% if case.associatedValues.first.typeName.description == "UIImage" %}
+        public enum ErrorImage: Swift.Error {
+            case encodeRawImage(UIImage)
+            case decodeRawImage
+        }
+    {% endif %}
+{% endfor %}
+{% endmacro %}
+
+{% macro structForMultyValue enum %}
+{% for case in enum.cases %}
+    {% if case.associatedValues.all.count > 1 %}
+        public struct {{ case.name|capitalize }}Controls: Codable {
+            {% for associatedValue in case.associatedValues %}
+                let {{ associatedValue.localName }}{% if not forloop.last %}{% endif %}: {{ associatedValue.type.name }}
+            {% endfor %}
+}
+    {% endif %}
+{% endfor %}
+{% endmacro %}
+
+{% macro init enum %}
+public init(from decoder: Decoder) throws {
+    let values = try decoder.container(keyedBy: EnumCodingKeys.self)
+    let `case` = try values.decode(Cases.self, forKey: .case)
+    switch `case` {
+    {% for case in enum.cases %}
+    case .{{ case.name }}:
+        {% if case.hasAssociatedValue %}
+            {% if case.associatedValues.all.count > 1 %}
+                let {{ case.name }}Controls = try values.decode({{ case.name|capitalize }}Controls.self, forKey: .value)
+                self = .{{ case.name }}({% for associatedValue in case.associatedValues %}{{ associatedValue.localName }}: {{ case.name }}Controls.{{associatedValue.localName}}{% if not forloop.last %},{% endif %}{% endfor %})
+            {% else %}
+                {% if case.associatedValues.first.typeName.description == "UIImage" %}
+                    throw ErrorImage.decodeRawImage
+                {% else %}
+                    {% if case.associatedValues.isOptional %}
+                        self = .{{ case.name }}({% if case.associatedValues.first.localName != nil %} {{ case.associatedValues.first.localName }}:{% endif %} try values.decode({% if case.associatedValues.first.type.name != nil %} {{ case.associatedValues.first.type.name }}.self{% else %}{{ case.associatedValues.first.typeName }}.self{% endif %}, forKey: .value))
+                    {% else %}
+                    self = .{{ case.name }}({% if case.associatedValues.first.localName != nil %} {{ case.associatedValue.first.localName }}:{% endif %}try values.decode({{ case.associatedValues.first.type.name }}.self, forKey: .value))
+                    {% endif %}
+                {% endif %}
+            {% endif %}
+        {% else %}
+            self = .{{ case.name }}
+    {% endif %}
+{% endfor %}
+}
+return
+}
+{% endmacro %}
+
+
+{% macro encode enum %}
+public func encode(to encoder: Encoder) throws {
+var container = encoder.container(keyedBy: EnumCodingKeys.self)
+switch self {
+{% for case in enum.cases %}
+    {% if case.hasAssociatedValue %}
+        {% if case.associatedValues.all.count > 1 %}
+            case .{{ case.name }}({% for associatedValue in case.associatedValues %} let {{ associatedValue.localName }}{% if not forloop.last %},{% endif %}{% endfor %}):
+            let {{ case.name }}Controls = {{ case.name|capitalize }}Controls({% for associatedValue in case.associatedValues %} {{ associatedValue.localName }}: {{ associatedValue.localName }}{% if not forloop.last %},{% endif %}{% endfor %})
+            try container.encode(Cases.{{ case.name }}, forKey: .case)
+            try container.encode({{ case.name }}Controls, forKey: .value)
+        {% else %}
+            case .{{ case.name }}(let variable):
+            {% if case.associatedValues.first.typeName.description == "UIImage" %}
+                throw ErrorImage.encodeRawImage(variable)
+            {% else %}
+            try container.encode(Cases.{{ case.name }}, forKey: .case)
+            try container.encode(variable, forKey: .value)
+            {% endif %}
+        {% endif %}
+    {% else %}
+        case .{{ case.name }}:
+        try container.encode(Cases.{{ case.name }}, forKey: .case)
+    {% endif %}
+{% endfor %}
+}
+}
+{% endmacro %}
+
+
+{% for enum in types.implementing.AutoCodable|enum %}
+
+extension {{ enum.name }}: Codable {
+
+{% call value enum %}
+
+{% call error enum%}
+
+{% call structForMultyValue enum %}
+
+{% call init enum %}
+
+{% call encode enum %}
+
+}
+{% endfor %}


### PR DESCRIPTION
To reduce writing repetitive code was implementing autogenerated code for Codable by using sourcery. `protocol AutoCodable` was implemented to mark enums which have to be extended  by `protocol Codable` (same why we have in `Prism` for generating enumPrism)
Codable.stensil have been added to replace Codable.swift and make project looks cleaner.