### PR TITLE
Removed controlsHidden check for Replay button

### DIFF
--- a/PlayerControls/sources/ContentControlsUIProps.swift
+++ b/PlayerControls/sources/ContentControlsUIProps.swift
@@ -105,7 +105,7 @@ extension DefaultControlsViewController {
             
             pauseButtonAction = props.player?.item.playable?.playbackAction.pause ?? .nop
             
-            replayButtonHidden = props.player?.item.playable?.playbackAction.replay == nil || controlsHidden
+            replayButtonHidden = props.player?.item.playable?.playbackAction.replay == nil
             
             replayButtonAction = props.player?.item.playable?.playbackAction.replay ?? .nop
             


### PR DESCRIPTION
The Replay's visibility now depends only on uiProps state, so it wouldn't disappear on tap anymore.