### PR TITLE
Added iPhone X Support

### DIFF
--- a/PlayerControls/resources/AdVideoControls.xib
+++ b/PlayerControls/resources/AdVideoControls.xib
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -34,6 +35,10 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
+                <view alpha="0.5" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="6pD-AF-L5f" userLabel="Shadow View">
+                    <rect key="frame" x="0.0" y="627" width="375" height="40"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qIL-ei-EYl">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="627"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -50,9 +55,8 @@
                         <constraint firstAttribute="height" constant="174" id="GVo-OR-nMU"/>
                     </constraints>
                 </view>
-                <view alpha="0.5" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="xUJ-hB-tQp" userLabel="Shadow View">
+                <view contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="xUJ-hB-tQp" userLabel="Controls View">
                     <rect key="frame" x="0.0" y="627" width="375" height="40"/>
-                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Advertisement" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="unl-Sw-N45">
                     <rect key="frame" x="50" y="648" width="77" height="14"/>
@@ -79,7 +83,7 @@
                     </accessibility>
                 </imageView>
                 <button hidden="YES" opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5ug-VD-17T">
-                    <rect key="frame" x="305" y="10" width="60" height="27"/>
+                    <rect key="frame" x="305" y="20" width="60" height="27"/>
                     <color key="backgroundColor" red="0.11372549019607843" green="0.10196078431372549" blue="0.12549019607843137" alpha="0.40000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="27" id="IeC-Cy-8jB"/>
@@ -175,33 +179,40 @@
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="qIL-ei-EYl" secondAttribute="trailing" id="3hW-FM-9ca"/>
                 <constraint firstItem="Qev-Mi-7eg" firstAttribute="centerX" secondItem="GG0-Gw-iIe" secondAttribute="centerX" id="6Da-80-PTC"/>
+                <constraint firstItem="6pD-AF-L5f" firstAttribute="leading" secondItem="GG0-Gw-iIe" secondAttribute="leading" id="8AR-Jf-Sit"/>
                 <constraint firstItem="unl-Sw-N45" firstAttribute="top" secondItem="xUJ-hB-tQp" secondAttribute="bottom" constant="-19" id="9Ib-35-9LD"/>
                 <constraint firstItem="unl-Sw-N45" firstAttribute="top" secondItem="OkK-Gw-Woe" secondAttribute="bottom" constant="8" id="Chg-Un-fBY"/>
                 <constraint firstItem="vqW-yt-m6i" firstAttribute="centerY" secondItem="xUJ-hB-tQp" secondAttribute="centerY" id="JtB-W4-hFr"/>
                 <constraint firstItem="vqW-yt-m6i" firstAttribute="top" secondItem="ZdZ-pr-J12" secondAttribute="top" id="KQl-9o-ngN"/>
                 <constraint firstItem="vqW-yt-m6i" firstAttribute="top" secondItem="EKe-z8-rXd" secondAttribute="top" id="LMh-OI-TJ1"/>
-                <constraint firstItem="5ug-VD-17T" firstAttribute="top" secondItem="GG0-Gw-iIe" secondAttribute="top" constant="10" id="MkK-de-rXB"/>
+                <constraint firstItem="5ug-VD-17T" firstAttribute="top" secondItem="rzL-au-f5q" secondAttribute="top" constant="20" id="MkK-de-rXB">
+                    <variation key="heightClass=regular" constant="0.0"/>
+                </constraint>
                 <constraint firstItem="OkK-Gw-Woe" firstAttribute="trailing" secondItem="8JH-hm-H4n" secondAttribute="trailing" id="RuL-dw-0cG"/>
                 <constraint firstItem="qIL-ei-EYl" firstAttribute="leading" secondItem="GG0-Gw-iIe" secondAttribute="leading" id="Wt0-et-CRA"/>
-                <constraint firstAttribute="bottom" secondItem="xUJ-hB-tQp" secondAttribute="bottom" id="Yjf-s7-2VR"/>
-                <constraint firstItem="xUJ-hB-tQp" firstAttribute="leading" secondItem="GG0-Gw-iIe" secondAttribute="leading" id="Yzx-vs-hdT"/>
+                <constraint firstItem="rzL-au-f5q" firstAttribute="bottom" secondItem="xUJ-hB-tQp" secondAttribute="bottom" id="Yjf-s7-2VR"/>
+                <constraint firstItem="xUJ-hB-tQp" firstAttribute="leading" secondItem="rzL-au-f5q" secondAttribute="leading" id="Yzx-vs-hdT"/>
+                <constraint firstItem="6pD-AF-L5f" firstAttribute="top" secondItem="xUJ-hB-tQp" secondAttribute="top" id="bcE-d5-o35"/>
+                <constraint firstAttribute="bottom" secondItem="6pD-AF-L5f" secondAttribute="bottom" id="bfU-fz-oQB"/>
                 <constraint firstItem="vqW-yt-m6i" firstAttribute="bottom" secondItem="unl-Sw-N45" secondAttribute="bottom" id="bm1-gl-GKq"/>
                 <constraint firstItem="vqW-yt-m6i" firstAttribute="leading" secondItem="EKe-z8-rXd" secondAttribute="leading" id="bxH-ZT-O0p"/>
                 <constraint firstItem="qIL-ei-EYl" firstAttribute="top" secondItem="GG0-Gw-iIe" secondAttribute="top" id="fFk-p9-gZW"/>
                 <constraint firstItem="Qev-Mi-7eg" firstAttribute="centerY" secondItem="GG0-Gw-iIe" secondAttribute="centerY" id="fPi-aF-QsS"/>
                 <constraint firstItem="OkK-Gw-Woe" firstAttribute="leading" secondItem="unl-Sw-N45" secondAttribute="leading" id="iU0-rh-ErI"/>
-                <constraint firstAttribute="trailing" secondItem="OkK-Gw-Woe" secondAttribute="trailing" constant="10" id="loR-ZW-HCb"/>
+                <constraint firstItem="rzL-au-f5q" firstAttribute="trailing" secondItem="OkK-Gw-Woe" secondAttribute="trailing" constant="10" id="loR-ZW-HCb"/>
+                <constraint firstItem="rzL-au-f5q" firstAttribute="trailing" secondItem="5ug-VD-17T" secondAttribute="trailing" constant="10" id="mlA-ay-MP4"/>
                 <constraint firstItem="8JH-hm-H4n" firstAttribute="centerY" secondItem="unl-Sw-N45" secondAttribute="centerY" id="mxg-x4-MZQ"/>
                 <constraint firstItem="OkK-Gw-Woe" firstAttribute="leading" secondItem="vqW-yt-m6i" secondAttribute="trailing" constant="10" id="p4q-dj-Rdq"/>
-                <constraint firstAttribute="trailing" secondItem="xUJ-hB-tQp" secondAttribute="trailing" id="p8T-PK-L6E"/>
-                <constraint firstItem="OkK-Gw-Woe" firstAttribute="leading" secondItem="GG0-Gw-iIe" secondAttribute="leading" constant="50" id="pU9-4L-FS3"/>
+                <constraint firstItem="rzL-au-f5q" firstAttribute="trailing" secondItem="xUJ-hB-tQp" secondAttribute="trailing" id="p8T-PK-L6E"/>
+                <constraint firstItem="OkK-Gw-Woe" firstAttribute="leading" secondItem="rzL-au-f5q" secondAttribute="leading" constant="50" id="pU9-4L-FS3"/>
                 <constraint firstItem="vqW-yt-m6i" firstAttribute="leading" secondItem="ZdZ-pr-J12" secondAttribute="leading" id="pWu-Go-ZY7"/>
-                <constraint firstItem="OkK-Gw-Woe" firstAttribute="trailing" secondItem="5ug-VD-17T" secondAttribute="trailing" id="sIZ-cG-PLs"/>
+                <constraint firstAttribute="trailing" secondItem="6pD-AF-L5f" secondAttribute="trailing" id="qVx-Lu-emS"/>
                 <constraint firstItem="xUJ-hB-tQp" firstAttribute="top" secondItem="qIL-ei-EYl" secondAttribute="bottom" id="y1r-bj-6QR"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <nil key="simulatedTopBarMetrics"/>
             <edgeInsets key="layoutMargins" top="60" left="8" bottom="8" right="8"/>
+            <viewLayoutGuide key="safeArea" id="rzL-au-f5q"/>
             <connections>
                 <outletCollection property="gestureRecognizers" destination="d0R-AA-BiQ" appends="YES" id="enl-Ej-F3H"/>
             </connections>

--- a/PlayerControls/resources/DefaultControlsViewController.xib
+++ b/PlayerControls/resources/DefaultControlsViewController.xib
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina3_5" orientation="landscape">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,9 +16,9 @@
                 <outlet property="airplayActiveLabel" destination="kPK-Sh-8jh" id="JaP-cu-vma"/>
                 <outlet property="airplayEdgeTrailingConstrains" destination="QZF-YX-TTy" id="zAV-I0-xeo"/>
                 <outlet property="airplayPipTrailingConstrains" destination="Rmc-6f-Sga" id="7AY-u1-OE5"/>
-                <outlet property="bottomItemsAndSeekerAnimatedConstraint" destination="7au-pl-AdU" id="C2t-3O-Zul"/>
+                <outlet property="bottomItemsAndSeekerAnimatedConstraint" destination="AaZ-HS-ARB" id="LCs-Di-Jb7"/>
                 <outlet property="bottomItemsHeightConstraint" destination="grI-1x-tIl" id="xfT-MT-O38"/>
-                <outlet property="bottomItemsInvisibleConstraint" destination="bIH-ZD-ij1" id="lIV-lW-rbF"/>
+                <outlet property="bottomItemsInvisibleConstraint" destination="wZk-la-hLQ" id="9JR-gp-dVe"/>
                 <outlet property="bottomItemsSeekerConstraint" destination="dM6-vN-wjR" id="4Uf-Ja-4Cb"/>
                 <outlet property="bottomItemsView" destination="8y7-Mc-uq8" id="KFT-1o-P2P"/>
                 <outlet property="bottomItemsVisibleConstraint" destination="jGJ-02-tF0" id="6Of-Um-71Z"/>
@@ -32,6 +33,7 @@
                 <outlet property="errorLabel" destination="UtD-cb-Wlb" id="ebo-gb-gDd"/>
                 <outlet property="liveDotLabel" destination="5Hj-Mr-azG" id="4IE-zq-M31"/>
                 <outlet property="liveIndicationView" destination="aUE-Db-Ht9" id="3TF-6f-Ijr"/>
+                <outlet property="liveViewTopConstraint" destination="8xl-GB-75a" id="u7k-aX-8EW"/>
                 <outlet property="loadingImageView" destination="ikX-6f-FSq" id="VZj-CY-bUg"/>
                 <outlet property="nextButton" destination="ida-wI-kAP" id="VKy-6n-hIb"/>
                 <outlet property="pauseButton" destination="KeK-cX-xXB" id="ItP-y0-YdS"/>
@@ -44,9 +46,9 @@
                 <outlet property="seekForwardButton" destination="djN-u7-nkt" id="u1p-O8-TOL"/>
                 <outlet property="seekerView" destination="fAO-vH-cgi" id="mC9-GB-wqD"/>
                 <outlet property="settingsButton" destination="Ddy-Jb-aVD" id="iE1-re-XF5"/>
-                <outlet property="shadowView" destination="m54-Yx-R7K" id="UrZ-Ce-oXW"/>
+                <outlet property="shadowView" destination="m54-Yx-R7K" id="Dks-zZ-ydL"/>
                 <outlet property="sideBarBottomConstraint" destination="coa-PV-KiP" id="aw7-zz-bPT"/>
-                <outlet property="sideBarInvisibleConstraint" destination="Yy9-r3-97c" id="TgC-vy-QtR"/>
+                <outlet property="sideBarInvisibleConstraint" destination="xts-BM-Eo3" id="zTC-AY-9Wa"/>
                 <outlet property="sideBarSeekerConstraint" destination="EEn-7U-jDF" id="m3S-Fa-6x6"/>
                 <outlet property="sideBarView" destination="Uc8-v7-96O" id="4eK-qd-dwS"/>
                 <outlet property="sideBarVisibleConstraint" destination="Pzo-A9-BH0" id="dIe-Ja-5aF"/>
@@ -83,14 +85,14 @@ Subtitles</string>
                     <rect key="frame" x="0.0" y="0.0" width="480" height="320"/>
                     <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
                 </imageView>
+                <view alpha="0.29999999999999999" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="m54-Yx-R7K" userLabel="Shadow View">
+                    <rect key="frame" x="0.0" y="0.0" width="480" height="320"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fi9-sW-1VX" userLabel="Controls view">
                     <rect key="frame" x="0.0" y="0.0" width="480" height="320"/>
                     <subviews>
-                        <view alpha="0.29999999999999999" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="m54-Yx-R7K" userLabel="Shadow View">
-                            <rect key="frame" x="0.0" y="0.0" width="480" height="320"/>
-                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        </view>
                         <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="icon-loading" translatesAutoresizingMaskIntoConstraints="NO" id="ikX-6f-FSq">
                             <rect key="frame" x="193" y="113" width="95" height="95"/>
                             <accessibility key="accessibilityConfiguration" label="Loading content video">
@@ -182,7 +184,7 @@ Subtitles</string>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                         </view>
                         <view hidden="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="57" translatesAutoresizingMaskIntoConstraints="NO" id="fAO-vH-cgi" customClass="SeekerControlView" customModule="PlayerControls" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="203" width="480" height="55"/>
+                            <rect key="frame" x="0.0" y="203" width="480" height="55.5"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <accessibility key="accessibilityConfiguration">
                                 <accessibilityTraits key="traits" adjustable="YES"/>
@@ -198,14 +200,14 @@ Subtitles</string>
                             </userDefinedRuntimeAttributes>
                         </view>
                         <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00:00" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Im0-Vw-2gZ">
-                            <rect key="frame" x="431" y="255" width="32" height="14"/>
+                            <rect key="frame" x="431" y="255.5" width="32" height="14"/>
                             <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
                             <color key="textColor" red="0.81568627450980391" green="0.81568627450980391" blue="0.81568627450980391" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8y7-Mc-uq8" userLabel="Bottom Items View">
-                            <rect key="frame" x="0.0" y="259.5" width="480" height="60"/>
+                            <rect key="frame" x="0.0" y="260" width="480" height="60"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="98K-SA-Pdv">
                                     <rect key="frame" x="15" y="3" width="35" height="43"/>
@@ -278,9 +280,7 @@ Title</string>
                     <constraints>
                         <constraint firstItem="U8A-X2-cyf" firstAttribute="leading" secondItem="cNh-R2-LdG" secondAttribute="trailing" constant="6" id="1RA-jh-Xfd"/>
                         <constraint firstItem="KeK-cX-xXB" firstAttribute="centerX" secondItem="U8A-X2-cyf" secondAttribute="centerX" id="2EN-h1-ldw"/>
-                        <constraint firstAttribute="trailing" secondItem="m54-Yx-R7K" secondAttribute="trailing" id="3f9-SO-RA2"/>
                         <constraint firstItem="djN-u7-nkt" firstAttribute="centerY" secondItem="U8A-X2-cyf" secondAttribute="centerY" id="79p-mr-0NO"/>
-                        <constraint firstAttribute="bottom" secondItem="fAO-vH-cgi" secondAttribute="top" id="7au-pl-AdU"/>
                         <constraint firstItem="KeK-cX-xXB" firstAttribute="centerY" secondItem="U8A-X2-cyf" secondAttribute="centerY" id="Bug-m8-Fqm"/>
                         <constraint firstItem="Uc8-v7-96O" firstAttribute="top" secondItem="fi9-sW-1VX" secondAttribute="top" id="DWa-IY-lCj"/>
                         <constraint firstItem="fAO-vH-cgi" firstAttribute="top" secondItem="Uc8-v7-96O" secondAttribute="bottom" priority="750" constant="-23" id="EEn-7U-jDF"/>
@@ -290,18 +290,13 @@ Title</string>
                         <constraint firstItem="l0O-oR-0Rg" firstAttribute="leading" secondItem="fi9-sW-1VX" secondAttribute="leading" constant="10" id="JdE-Uf-1u0"/>
                         <constraint firstItem="cNh-R2-LdG" firstAttribute="centerY" secondItem="U8A-X2-cyf" secondAttribute="centerY" id="MDB-2d-aWk"/>
                         <constraint firstItem="fAO-vH-cgi" firstAttribute="leading" secondItem="fi9-sW-1VX" secondAttribute="leading" id="OYY-c7-642"/>
-                        <constraint firstItem="m54-Yx-R7K" firstAttribute="centerY" secondItem="U8A-X2-cyf" secondAttribute="centerY" id="PrJ-1T-4v4"/>
                         <constraint firstAttribute="trailing" secondItem="Uc8-v7-96O" secondAttribute="trailing" constant="0.5" id="Pzo-A9-BH0"/>
                         <constraint firstAttribute="trailing" secondItem="fAO-vH-cgi" secondAttribute="trailing" id="SFG-A0-7XF"/>
                         <constraint firstItem="8y7-Mc-uq8" firstAttribute="leading" secondItem="fi9-sW-1VX" secondAttribute="leading" id="Svu-2t-QSO"/>
-                        <constraint firstAttribute="trailing" secondItem="Uc8-v7-96O" secondAttribute="leading" id="Yy9-r3-97c"/>
-                        <constraint firstAttribute="bottom" secondItem="8y7-Mc-uq8" secondAttribute="top" id="bIH-ZD-ij1"/>
                         <constraint firstItem="8y7-Mc-uq8" firstAttribute="top" secondItem="fAO-vH-cgi" secondAttribute="bottom" constant="1.5" id="dM6-vN-wjR"/>
                         <constraint firstAttribute="trailing" secondItem="Im0-Vw-2gZ" secondAttribute="trailing" constant="17" id="eTt-xT-Hay"/>
-                        <constraint firstItem="m54-Yx-R7K" firstAttribute="top" secondItem="fi9-sW-1VX" secondAttribute="top" id="fv1-Ls-gs3"/>
                         <constraint firstItem="ikX-6f-FSq" firstAttribute="centerY" secondItem="U8A-X2-cyf" secondAttribute="centerY" id="g57-te-Fqp"/>
                         <constraint firstItem="ikX-6f-FSq" firstAttribute="centerX" secondItem="U8A-X2-cyf" secondAttribute="centerX" id="hHz-DU-eUK"/>
-                        <constraint firstItem="m54-Yx-R7K" firstAttribute="leading" secondItem="fi9-sW-1VX" secondAttribute="leading" id="iTM-by-B9G"/>
                         <constraint firstItem="Im0-Vw-2gZ" firstAttribute="top" secondItem="fAO-vH-cgi" secondAttribute="bottom" constant="-3" id="if2-R8-sVs"/>
                         <constraint firstItem="ida-wI-kAP" firstAttribute="leading" secondItem="djN-u7-nkt" secondAttribute="trailing" constant="9.5" id="iww-Ws-dSP">
                             <variation key="widthClass=compact" constant="10"/>
@@ -329,7 +324,6 @@ Title</string>
                     </constraints>
                     <variation key="default">
                         <mask key="subviews">
-                            <exclude reference="m54-Yx-R7K"/>
                             <exclude reference="wVE-Q8-zOG"/>
                             <exclude reference="U8A-X2-cyf"/>
                             <exclude reference="KeK-cX-xXB"/>
@@ -343,18 +337,16 @@ Title</string>
                             <exclude reference="HWP-bD-q7I"/>
                             <exclude reference="MDB-2d-aWk"/>
                             <exclude reference="sZA-Tb-Cie"/>
-                            <exclude reference="7au-pl-AdU"/>
                             <exclude reference="EEn-7U-jDF"/>
                             <exclude reference="OYY-c7-642"/>
                             <exclude reference="SFG-A0-7XF"/>
                             <exclude reference="put-WR-Szd"/>
-                            <exclude reference="g57-te-Fqp"/>
-                            <exclude reference="hHz-DU-eUK"/>
-                            <exclude reference="bIH-ZD-ij1"/>
                             <exclude reference="2EN-h1-ldw"/>
                             <exclude reference="Bug-m8-Fqm"/>
                             <exclude reference="1RA-jh-Xfd"/>
                             <exclude reference="sPA-I1-YzI"/>
+                            <exclude reference="g57-te-Fqp"/>
+                            <exclude reference="hHz-DU-eUK"/>
                             <exclude reference="y9t-79-v13"/>
                             <exclude reference="xAL-Mr-aiA"/>
                             <exclude reference="zsd-wr-B4P"/>
@@ -364,13 +356,11 @@ Title</string>
                             <exclude reference="iww-Ws-dSP"/>
                             <exclude reference="DWa-IY-lCj"/>
                             <exclude reference="Pzo-A9-BH0"/>
-                            <exclude reference="Yy9-r3-97c"/>
                             <exclude reference="eTt-xT-Hay"/>
                         </mask>
                     </variation>
                     <variation key="widthClass=compact">
                         <mask key="subviews">
-                            <include reference="m54-Yx-R7K"/>
                             <include reference="wVE-Q8-zOG"/>
                             <include reference="U8A-X2-cyf"/>
                             <include reference="KeK-cX-xXB"/>
@@ -388,12 +378,12 @@ Title</string>
                             <include reference="OYY-c7-642"/>
                             <include reference="SFG-A0-7XF"/>
                             <include reference="put-WR-Szd"/>
-                            <include reference="g57-te-Fqp"/>
-                            <include reference="hHz-DU-eUK"/>
                             <include reference="2EN-h1-ldw"/>
                             <include reference="Bug-m8-Fqm"/>
                             <include reference="1RA-jh-Xfd"/>
                             <include reference="sPA-I1-YzI"/>
+                            <include reference="g57-te-Fqp"/>
+                            <include reference="hHz-DU-eUK"/>
                             <include reference="y9t-79-v13"/>
                             <include reference="xAL-Mr-aiA"/>
                             <include reference="zsd-wr-B4P"/>
@@ -408,7 +398,6 @@ Title</string>
                     </variation>
                     <variation key="widthClass=regular">
                         <mask key="subviews">
-                            <include reference="m54-Yx-R7K"/>
                             <include reference="wVE-Q8-zOG"/>
                             <include reference="U8A-X2-cyf"/>
                             <include reference="KeK-cX-xXB"/>
@@ -426,12 +415,12 @@ Title</string>
                             <include reference="OYY-c7-642"/>
                             <include reference="SFG-A0-7XF"/>
                             <include reference="put-WR-Szd"/>
-                            <include reference="g57-te-Fqp"/>
-                            <include reference="hHz-DU-eUK"/>
                             <include reference="2EN-h1-ldw"/>
                             <include reference="Bug-m8-Fqm"/>
                             <include reference="1RA-jh-Xfd"/>
                             <include reference="sPA-I1-YzI"/>
+                            <include reference="g57-te-Fqp"/>
+                            <include reference="hHz-DU-eUK"/>
                             <include reference="y9t-79-v13"/>
                             <include reference="xAL-Mr-aiA"/>
                             <include reference="zsd-wr-B4P"/>
@@ -502,10 +491,13 @@ Title</string>
             </subviews>
             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
+                <constraint firstItem="m54-Yx-R7K" firstAttribute="top" secondItem="rFH-6N-3gH" secondAttribute="top" id="1qs-UH-6FA"/>
                 <constraint firstItem="NKq-bU-tvG" firstAttribute="top" secondItem="rFH-6N-3gH" secondAttribute="top" id="24r-Hq-M3g"/>
-                <constraint firstAttribute="bottom" secondItem="fi9-sW-1VX" secondAttribute="bottom" id="33F-58-Fc1"/>
+                <constraint firstItem="deC-QD-Vef" firstAttribute="bottom" secondItem="fi9-sW-1VX" secondAttribute="bottom" id="33F-58-Fc1"/>
+                <constraint firstItem="m54-Yx-R7K" firstAttribute="leading" secondItem="rFH-6N-3gH" secondAttribute="leading" id="6Eh-I1-MKf"/>
                 <constraint firstItem="IVo-gm-8qs" firstAttribute="top" secondItem="kPK-Sh-8jh" secondAttribute="bottom" constant="20" id="7Wz-dr-n9W"/>
                 <constraint firstItem="aUE-Db-Ht9" firstAttribute="top" secondItem="rFH-6N-3gH" secondAttribute="top" constant="20" id="8xl-GB-75a"/>
+                <constraint firstAttribute="bottom" secondItem="fAO-vH-cgi" secondAttribute="top" id="AaZ-HS-ARB"/>
                 <constraint firstItem="Uc8-v7-96O" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="UtD-cb-Wlb" secondAttribute="trailing" constant="10" id="FtY-J6-Kdm"/>
                 <constraint firstItem="UtD-cb-Wlb" firstAttribute="centerY" secondItem="fi9-sW-1VX" secondAttribute="centerY" constant="-60" id="Jcc-XU-IcT">
                     <variation key="heightClass=regular-widthClass=regular" constant="-120"/>
@@ -515,22 +507,30 @@ Title</string>
                 <constraint firstAttribute="bottom" secondItem="NKq-bU-tvG" secondAttribute="bottom" id="Vog-pm-tOS"/>
                 <constraint firstItem="IVo-gm-8qs" firstAttribute="centerX" secondItem="rFH-6N-3gH" secondAttribute="centerX" id="ZsG-TS-eKR"/>
                 <constraint firstItem="NKq-bU-tvG" firstAttribute="leading" secondItem="rFH-6N-3gH" secondAttribute="leading" id="cUc-Ko-vsy"/>
-                <constraint firstItem="fi9-sW-1VX" firstAttribute="top" secondItem="rFH-6N-3gH" secondAttribute="top" id="cbb-BO-G5L"/>
+                <constraint firstItem="fi9-sW-1VX" firstAttribute="top" secondItem="deC-QD-Vef" secondAttribute="top" id="cbb-BO-G5L"/>
                 <constraint firstAttribute="bottom" secondItem="Uc8-v7-96O" secondAttribute="bottom" constant="70" id="coa-PV-KiP"/>
                 <constraint firstItem="UtD-cb-Wlb" firstAttribute="centerX" secondItem="rFH-6N-3gH" secondAttribute="centerX" id="daT-2G-R8Z"/>
-                <constraint firstAttribute="trailing" secondItem="fi9-sW-1VX" secondAttribute="trailing" id="eNx-qY-amb"/>
+                <constraint firstItem="deC-QD-Vef" firstAttribute="trailing" secondItem="fi9-sW-1VX" secondAttribute="trailing" id="eNx-qY-amb"/>
                 <constraint firstItem="IVo-gm-8qs" firstAttribute="centerY" secondItem="rFH-6N-3gH" secondAttribute="centerY" constant="0.16666666666668561" id="g2S-a8-EXu"/>
                 <constraint firstAttribute="bottom" secondItem="SEd-qf-YJr" secondAttribute="bottom" constant="110" id="gK7-AG-J2d">
                     <variation key="heightClass=regular" constant="130"/>
                 </constraint>
                 <constraint firstAttribute="trailing" secondItem="NKq-bU-tvG" secondAttribute="trailing" id="giY-J7-3C9"/>
+                <constraint firstAttribute="bottom" secondItem="m54-Yx-R7K" secondAttribute="bottom" id="iOy-aw-CDH"/>
                 <constraint firstItem="aUE-Db-Ht9" firstAttribute="leading" secondItem="rFH-6N-3gH" secondAttribute="leading" constant="10" id="mZh-yz-9m2"/>
+                <constraint firstAttribute="trailing" secondItem="m54-Yx-R7K" secondAttribute="trailing" id="sYk-cA-d5I"/>
                 <constraint firstItem="UtD-cb-Wlb" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="rFH-6N-3gH" secondAttribute="leading" constant="40" id="ute-YD-JsE"/>
-                <constraint firstItem="fi9-sW-1VX" firstAttribute="leading" secondItem="rFH-6N-3gH" secondAttribute="leading" id="vK8-8v-dJz"/>
+                <constraint firstItem="fi9-sW-1VX" firstAttribute="leading" secondItem="deC-QD-Vef" secondAttribute="leading" id="vK8-8v-dJz"/>
+                <constraint firstAttribute="bottom" secondItem="8y7-Mc-uq8" secondAttribute="top" id="wZk-la-hLQ"/>
+                <constraint firstAttribute="trailing" secondItem="Uc8-v7-96O" secondAttribute="leading" id="xts-BM-Eo3"/>
             </constraints>
+            <viewLayoutGuide key="safeArea" id="deC-QD-Vef"/>
             <variation key="default">
                 <mask key="constraints">
+                    <exclude reference="AaZ-HS-ARB"/>
+                    <exclude reference="wZk-la-hLQ"/>
                     <exclude reference="coa-PV-KiP"/>
+                    <exclude reference="xts-BM-Eo3"/>
                 </mask>
             </variation>
             <connections>

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -62,6 +62,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     @IBOutlet private var subtitlesAirplayTrailingConstrains: NSLayoutConstraint!
     @IBOutlet private var subtitlesEdgeTrailingConstrains: NSLayoutConstraint!
     @IBOutlet private var subtitlesPipTrailingConstrains: NSLayoutConstraint!
+    @IBOutlet private var liveViewTopConstraint: NSLayoutConstraint!
     
     @IBOutlet private var bottomItemsAndSeekerAnimatedConstraint: NSLayoutConstraint!
     @IBOutlet private var bottomItemsVisibleConstraint: NSLayoutConstraint!
@@ -335,11 +336,14 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         
         switch uiProps.sideBarViewHidden {
         case true:
+            sideBarBottomConstraint.constant = {
+                guard #available(iOS 11, *) else { return view.frame.height - sideBarView.frame.height }
+                return view.frame.height - sideBarView.frame.height - view.safeAreaInsets.top
+            }()
             sideBarVisibleConstraint.isActive = false
             sideBarInvisibleConstraint.isActive = true
             
             sideBarBottomConstraint.isActive = true
-            sideBarBottomConstraint.constant =  view.frame.height - sideBarView.frame.height
             
             afterSlideAnimation {
                 self.sideBarView.isHidden = true
@@ -466,6 +470,13 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         }
         compasDirectionView.transform = uiProps.compasDirectionViewTransform
         cameraPanGestureRecognizer.isEnabled = uiProps.cameraPanGestureIsEnabled
+        if #available(iOS 11.0, *) {
+            compassBodyNoLiveTopConstraint.constant = 20
+            liveViewTopConstraint.constant = 20
+        } else {
+            compassBodyNoLiveTopConstraint.constant = prefersStatusBarHidden ? 20 : 40
+            liveViewTopConstraint.constant = prefersStatusBarHidden ? 20 : 40
+        }
         
         ccTextLabel.isHidden = uiProps.subtitlesTextLabelHidden
         ccTextLabel.text = uiProps.subtitlesTextLabelText

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -127,6 +127,14 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     var task: URLSessionDataTask?
     private var animationsDuration: CFTimeInterval = 0.4
     
+    var shouldHideHomeIndicator = true
+    
+    @available(iOS 11.0, *)
+    override public func prefersHomeIndicatorAutoHidden() -> Bool
+    {
+        return shouldHideHomeIndicator
+    }
+    
     var uiProps: UIProps = UIProps(props: .noPlayer, controlsViewVisible: false)
     //swiftlint:disable function_body_length
     //swiftlint:disable cyclomatic_complexity
@@ -550,6 +558,15 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         if !uiProps.animationsEnabled || !state.controlsAnimationPossible {
             afterSlideAnimationActions.forEach{$0()}
             afterFadeAnimationActions.forEach{$0()}
+        }
+        if #available(iOS 11.0, *)  {
+            if uiProps.controlsViewHidden {
+                shouldHideHomeIndicator = true
+                setNeedsUpdateOfHomeIndicatorAutoHidden()
+            } else {
+                shouldHideHomeIndicator = false
+                setNeedsUpdateOfHomeIndicatorAutoHidden()
+            }
         }
     }
     


### PR DESCRIPTION
# Added updates for iPhone X support. 

## Progress for 01.03.2018:
- [x] Added safe areas for `Player Controls` in a current version of xib;
- [x] Changed animation constraints `bottomView`, `seekBar` and `sidebar`;
- [x] Added constraints fixes for `compasView` and `liveLabel` on iOS < 11;
- [x] Added fix for `sidebar` bottom constraint;
- [x] Added safe areas for `Ad Controls` and some changes for `ShadowView` and `SkipLabel`;
- [ ]  ~Snapshot tests safe area support (Snappy Shrimp framework bug).~ Will be fixed later

### Important note:
To get the `Home Indicator` hiding behavior from `DefaultViewController`, that will hide it right after controls, you should make `DefaultViewController` responsible for this hiding, using method `childViewControllerForHomeIndicatorAutoHidden` in the `rootViewController`.


## Player controls on iPhone X before/after

<img width="300" alt="old-port" src="https://user-images.githubusercontent.com/31652265/36854564-fe8cbc78-1d79-11e8-845c-45f7cf8e6cd7.png"> <img width="302" alt="new-port" src="https://user-images.githubusercontent.com/31652265/36854565-feaaf04e-1d79-11e8-9db0-5359cc2ac0fe.png">

<img width="668" alt="old-land" src="https://user-images.githubusercontent.com/31652265/36854572-0242cc04-1d7a-11e8-9c23-c2731c152106.png">
<img width="673" alt="new-land" src="https://user-images.githubusercontent.com/31652265/36854733-5b511dbe-1d7a-11e8-8c2b-b47d16238b36.png">

## Ad Controls on iPhone X before/after

<img width="314" alt="oldad-port" src="https://user-images.githubusercontent.com/31652265/36856780-82c78c48-1d7f-11e8-9f6d-ac141f688afb.png"> <img width="317" alt="newad-port" src="https://user-images.githubusercontent.com/31652265/36856781-82ec2724-1d7f-11e8-9124-05000b2355ab.png">

<img width="663" alt="oldad-land" src="https://user-images.githubusercontent.com/31652265/36856787-8752a69e-1d7f-11e8-94dc-d1aecc314b65.png">
<img width="665" alt="newad-land" src="https://user-images.githubusercontent.com/31652265/36856788-8775270a-1d7f-11e8-8fa9-c375fd0b546b.png">



## iPhone X with animations enabled

![landscape-iphonex](https://user-images.githubusercontent.com/31652265/36842610-db8eecac-1d54-11e8-822f-3cf0a1d436bc.gif)
![portrait-iphonex](https://user-images.githubusercontent.com/31652265/36842611-dbae103c-1d54-11e8-83b2-0b8816ec1784.gif)

@aol-public/mobile-sdk-team  Ready to review.
[JIRA Issue](https://jira.ops.aol.com/browse/OMSDK-722)