### PR TITLE
Hotfix for travis.yml and diffs deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,23 +8,14 @@ before_install:
 - bundle install
 - cd SnapshotTests
 - carthage update --platform iOS
-- curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-- unzip awscli-bundle.zip
-- sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
-- aws configure set default.region eu-west-2
-- aws configure set aws_access_key_id $AWS_ACCESS_KEY
-- aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
 
 script:
 - cd ..
 - fastlane test
 
 after_failure:
-- aws s3 rm --recursive s3://$S3_BUCKET/Failures/$TRAVIS_BRANCH/
-- aws s3 cp ./SnapshotTests/Tests/FailureDifferences s3://$S3_BUCKET/Failures/$TRAVIS_BRANCH/ --recursive --include "*.jpg" --exclude "*.DS_Store" --acl public-read
-- aws s3api list-objects --bucket aol-public --query 'Contents[].Key' --prefix Failures/$TRAVIS_BRANCH | tee keys.json
-- bundle exec danger --verbose
+- if [ $TRAVIS_PULL_REQUEST_SLUG == "aol-public/OneMobileSDK-controls-ios" ]; then . manage-diffs.sh; fi
+
 
 after_success:
-- aws s3 rm --recursive s3://$S3_BUCKET/Failures/$TRAVIS_BRANCH/
-- bundle exec danger --verbose
+- if [ "$TRAVIS_PULL_REQUEST_SLUG" == "aol-public/OneMobileSDK-controls-ios" ]; then . manage-diffs.sh; fi

--- a/manage-diffs.sh
+++ b/manage-diffs.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+unzip awscli-bundle.zip
+sudo ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+aws configure set default.region eu-west-2
+aws configure set aws_access_key_id $AWS_ACCESS_KEY
+aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+
+if [ $TRAVIS_TEST_RESULT != 0 ]; then
+    if [ -d ./SnapshotTests/Tests/FailureDifferences ]; then
+        aws s3 rm --recursive s3://$S3_BUCKET/Failures/$TRAVIS_BRANCH/;
+        aws s3 cp ./SnapshotTests/Tests/FailureDifferences s3://$S3_BUCKET/Failures/$TRAVIS_BRANCH/ --recursive --include "*.jpg" --exclude "*.DS_Store" --acl public-read;
+        aws s3api list-objects --bucket aol-public --query 'Contents[].Key' --prefix Failures/$TRAVIS_BRANCH | tee keys.json; bundle exec danger --verbose;
+    fi
+else
+    aws s3 rm --recursive s3://$S3_BUCKET/Failures/$TRAVIS_BRANCH/;
+    bundle exec danger --verbose;
+fi


### PR DESCRIPTION
Fixed an issue that errored pull-request build on Travis because of environmental variables that are not available on forks. Now it will be launched only if PR was made from **aol-public** branch
Also, the deployment configuration and the diff images management are now located in diffs-deploy.sh file.
[JIRA Issue](https://jira.ouroath.com/browse/OMSDK-770)