### PR TITLE
Added safe area for LIVE indicator 

### DIFF
--- a/PlayerControls/resources/DefaultControlsViewController.xib
+++ b/PlayerControls/resources/DefaultControlsViewController.xib
@@ -496,7 +496,7 @@ Title</string>
                 <constraint firstItem="deC-QD-Vef" firstAttribute="bottom" secondItem="fi9-sW-1VX" secondAttribute="bottom" id="33F-58-Fc1"/>
                 <constraint firstItem="m54-Yx-R7K" firstAttribute="leading" secondItem="rFH-6N-3gH" secondAttribute="leading" id="6Eh-I1-MKf"/>
                 <constraint firstItem="IVo-gm-8qs" firstAttribute="top" secondItem="kPK-Sh-8jh" secondAttribute="bottom" constant="20" id="7Wz-dr-n9W"/>
-                <constraint firstItem="aUE-Db-Ht9" firstAttribute="top" secondItem="rFH-6N-3gH" secondAttribute="top" constant="20" id="8xl-GB-75a"/>
+                <constraint firstItem="aUE-Db-Ht9" firstAttribute="top" secondItem="deC-QD-Vef" secondAttribute="top" constant="20" id="8xl-GB-75a"/>
                 <constraint firstAttribute="bottom" secondItem="fAO-vH-cgi" secondAttribute="top" id="AaZ-HS-ARB"/>
                 <constraint firstItem="Uc8-v7-96O" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="UtD-cb-Wlb" secondAttribute="trailing" constant="10" id="FtY-J6-Kdm"/>
                 <constraint firstItem="UtD-cb-Wlb" firstAttribute="centerY" secondItem="fi9-sW-1VX" secondAttribute="centerY" constant="-60" id="Jcc-XU-IcT">


### PR DESCRIPTION
I've added the `safe area` for the `Live indicator` for its `top anchor`.

Here's how it will look like:

![screen shot 2018-03-16 at 3 45 49 pm](https://user-images.githubusercontent.com/31652265/37523964-26b6fbec-2931-11e8-8ae3-96ebca66ed55.png)
![screen shot 2018-03-15 at 5 44 33 pm](https://user-images.githubusercontent.com/31652265/37523969-2be29392-2931-11e8-9493-915f5f8534cc.png)
