### PR TITLE
Turned off animations when seeking started

### DIFF
--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -108,9 +108,10 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     struct State {
         var hasAppeared = false
         var isTransitioning = false
+        var isSeekingInProgress = false
         
         var controlsAnimationPossible: Bool {
-            return hasAppeared
+            return hasAppeared && !isSeekingInProgress
         }
     }
     
@@ -882,6 +883,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     private func startSeek(from progress: CGFloat) {
         currentUIProps.startSeekAction.perform(with: .init(progress))
         onUserInteraction?.perform()
+        state.isSeekingInProgress = true
     }
     
     private func updateSeek(to progress: CGFloat) {
@@ -892,6 +894,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     private func stopSeek(at progress: CGFloat) {
         currentUIProps.stopSeekAction.perform(with: .init(progress))
         onUserInteraction?.perform()
+        state.isSeekingInProgress = false
     }
     
     @IBAction private func seekForwardButtonTouched() {


### PR DESCRIPTION
To improve UX, I've added a new state `isSeekingInProgress`. So now, when you start seeking, buttons disappear immediately, without fade.

| Before        | After           |
| ------------- |:-------------:|
| ![seeking-before](https://user-images.githubusercontent.com/31652265/37962744-ba2ea0f0-31c4-11e8-870a-c48dcc48f8b3.gif)      | ![seeking-after](https://user-images.githubusercontent.com/31652265/37962745-ba512d28-31c4-11e8-9553-7deaa8638bc0.gif) |

@aol-public/mobile-sdk-team: Ready for review.

[JIRA Issue](https://jira.ouroath.com/browse/OMSDK-845)