### PR TITLE
Play button is now always visible with thumbnail

### DIFF
--- a/PlayerControls/sources/ContentControlsUIProps.swift
+++ b/PlayerControls/sources/ContentControlsUIProps.swift
@@ -99,7 +99,11 @@ extension DefaultControlsViewController {
             
             loading = props.player?.item.playable?.loading ?? false
             
-            playButtonHidden = props.player?.item.playable?.playbackAction.play == nil || controlsHidden
+            playButtonHidden = {
+                let emptyPlaybackAcion = props.player?.item.playable?.playbackAction.play == nil
+                let thumbnailHidden = props.player?.item.playable?.thumbnail?.url == nil
+                return (emptyPlaybackAcion || controlsHidden) && thumbnailHidden
+            }()
             
             playButtonAction = props.player?.item.playable?.playbackAction.play ?? .nop
             


### PR DESCRIPTION
We've had a discussion about that and decided that if autoplay is turned off, play button should always be visible on the screen. We show thumbnails only when autoplay is off, so I've decided to extend visibility logic for the play button, that is now also based on the thumbnail visibility.

| Before        | After           |
| ------------- |:-------------:|
| ![autoplay-before](https://user-images.githubusercontent.com/31652265/37962940-6f093558-31c5-11e8-89b3-6e5ed2e99c64.gif)  | ![autoplay-after](https://user-images.githubusercontent.com/31652265/37962945-741ee790-31c5-11e8-9e30-da6b7a4f0c20.gif)
 |

@aol-public/mobile-sdk-team: Ready for review.

[JIRA Issue](https://jira.ouroath.com/browse/OMSDK-844)