### PR TITLE
Fixed constraint warnings

### DIFF
--- a/PlayerControls/resources/DefaultControlsViewController.xib
+++ b/PlayerControls/resources/DefaultControlsViewController.xib
@@ -294,7 +294,7 @@ Title</string>
                         <constraint firstAttribute="trailing" secondItem="Uc8-v7-96O" secondAttribute="trailing" constant="0.5" id="Pzo-A9-BH0"/>
                         <constraint firstAttribute="trailing" secondItem="fAO-vH-cgi" secondAttribute="trailing" id="SFG-A0-7XF"/>
                         <constraint firstItem="8y7-Mc-uq8" firstAttribute="leading" secondItem="fi9-sW-1VX" secondAttribute="leading" id="Svu-2t-QSO"/>
-                        <constraint firstItem="8y7-Mc-uq8" firstAttribute="top" secondItem="fAO-vH-cgi" secondAttribute="bottom" constant="1.5" id="dM6-vN-wjR"/>
+                        <constraint firstItem="8y7-Mc-uq8" firstAttribute="top" secondItem="fAO-vH-cgi" secondAttribute="bottom" priority="999" constant="1.5" id="dM6-vN-wjR"/>
                         <constraint firstAttribute="trailing" secondItem="Im0-Vw-2gZ" secondAttribute="trailing" constant="17" id="eTt-xT-Hay"/>
                         <constraint firstItem="ikX-6f-FSq" firstAttribute="centerY" secondItem="U8A-X2-cyf" secondAttribute="centerY" id="g57-te-Fqp"/>
                         <constraint firstItem="ikX-6f-FSq" firstAttribute="centerX" secondItem="U8A-X2-cyf" secondAttribute="centerX" id="hHz-DU-eUK"/>
@@ -325,100 +325,22 @@ Title</string>
                         <constraint firstItem="wVE-Q8-zOG" firstAttribute="centerX" secondItem="U8A-X2-cyf" secondAttribute="centerX" id="zsd-wr-B4P"/>
                     </constraints>
                     <variation key="default">
-                        <mask key="subviews">
-                            <exclude reference="wVE-Q8-zOG"/>
-                            <exclude reference="U8A-X2-cyf"/>
-                            <exclude reference="KeK-cX-xXB"/>
-                            <exclude reference="ida-wI-kAP"/>
-                            <exclude reference="73i-r1-qKj"/>
-                            <exclude reference="djN-u7-nkt"/>
-                            <exclude reference="cNh-R2-LdG"/>
-                        </mask>
                         <mask key="constraints">
-                            <exclude reference="HWP-bD-q7I"/>
-                            <exclude reference="MDB-2d-aWk"/>
-                            <exclude reference="sZA-Tb-Cie"/>
                             <exclude reference="nHZ-kA-JSd"/>
-                            <exclude reference="2EN-h1-ldw"/>
-                            <exclude reference="Bug-m8-Fqm"/>
-                            <exclude reference="1RA-jh-Xfd"/>
-                            <exclude reference="sPA-I1-YzI"/>
-                            <exclude reference="y9t-79-v13"/>
                             <exclude reference="g57-te-Fqp"/>
                             <exclude reference="hHz-DU-eUK"/>
-                            <exclude reference="xAL-Mr-aiA"/>
-                            <exclude reference="zsd-wr-B4P"/>
-                            <exclude reference="79p-mr-0NO"/>
-                            <exclude reference="pG8-cM-rpN"/>
-                            <exclude reference="F2z-D3-yET"/>
-                            <exclude reference="iww-Ws-dSP"/>
-                            <exclude reference="DWa-IY-lCj"/>
-                            <exclude reference="Pzo-A9-BH0"/>
-                            <exclude reference="eTt-xT-Hay"/>
                         </mask>
                     </variation>
                     <variation key="widthClass=compact">
-                        <mask key="subviews">
-                            <include reference="wVE-Q8-zOG"/>
-                            <include reference="U8A-X2-cyf"/>
-                            <include reference="KeK-cX-xXB"/>
-                            <include reference="ida-wI-kAP"/>
-                            <include reference="73i-r1-qKj"/>
-                            <include reference="djN-u7-nkt"/>
-                            <include reference="cNh-R2-LdG"/>
-                        </mask>
                         <mask key="constraints">
-                            <include reference="HWP-bD-q7I"/>
-                            <include reference="MDB-2d-aWk"/>
-                            <include reference="sZA-Tb-Cie"/>
-                            <include reference="2EN-h1-ldw"/>
-                            <include reference="Bug-m8-Fqm"/>
-                            <include reference="1RA-jh-Xfd"/>
-                            <include reference="sPA-I1-YzI"/>
-                            <include reference="y9t-79-v13"/>
                             <include reference="g57-te-Fqp"/>
                             <include reference="hHz-DU-eUK"/>
-                            <include reference="xAL-Mr-aiA"/>
-                            <include reference="zsd-wr-B4P"/>
-                            <include reference="79p-mr-0NO"/>
-                            <include reference="pG8-cM-rpN"/>
-                            <include reference="F2z-D3-yET"/>
-                            <include reference="iww-Ws-dSP"/>
-                            <include reference="DWa-IY-lCj"/>
-                            <include reference="Pzo-A9-BH0"/>
-                            <include reference="eTt-xT-Hay"/>
                         </mask>
                     </variation>
                     <variation key="widthClass=regular">
-                        <mask key="subviews">
-                            <include reference="wVE-Q8-zOG"/>
-                            <include reference="U8A-X2-cyf"/>
-                            <include reference="KeK-cX-xXB"/>
-                            <include reference="ida-wI-kAP"/>
-                            <include reference="73i-r1-qKj"/>
-                            <include reference="djN-u7-nkt"/>
-                            <include reference="cNh-R2-LdG"/>
-                        </mask>
                         <mask key="constraints">
-                            <include reference="HWP-bD-q7I"/>
-                            <include reference="MDB-2d-aWk"/>
-                            <include reference="sZA-Tb-Cie"/>
-                            <include reference="2EN-h1-ldw"/>
-                            <include reference="Bug-m8-Fqm"/>
-                            <include reference="1RA-jh-Xfd"/>
-                            <include reference="sPA-I1-YzI"/>
-                            <include reference="y9t-79-v13"/>
                             <include reference="g57-te-Fqp"/>
                             <include reference="hHz-DU-eUK"/>
-                            <include reference="xAL-Mr-aiA"/>
-                            <include reference="zsd-wr-B4P"/>
-                            <include reference="79p-mr-0NO"/>
-                            <include reference="pG8-cM-rpN"/>
-                            <include reference="F2z-D3-yET"/>
-                            <include reference="iww-Ws-dSP"/>
-                            <include reference="DWa-IY-lCj"/>
-                            <include reference="Pzo-A9-BH0"/>
-                            <include reference="eTt-xT-Hay"/>
                         </mask>
                     </variation>
                 </view>

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -204,11 +204,11 @@ public final class DefaultControlsViewController: ContentControlsViewController 
                 videoTitleLabel.text = nextUIProps.videoTitleLabelText
             }
             func setupBottomItemsConstraints() {
-                airplayPipTrailingConstrains.isActive = !nextUIProps.pipButtonHidden
-                airplayEdgeTrailingConstrains.isActive = nextUIProps.pipButtonHidden
+                airplayPipTrailingConstrains.isActive = !nextUIProps.pipButtonHidden && !nextUIProps.airplayButtonHidden
+                airplayEdgeTrailingConstrains.isActive = nextUIProps.pipButtonHidden && !nextUIProps.airplayButtonHidden
                 subtitlesAirplayTrailingConstrains.isActive = !nextUIProps.airplayButtonHidden
-                subtitlesEdgeTrailingConstrains.isActive = nextUIProps.airplayButtonHidden && nextUIProps.pipButtonHidden
-                subtitlesPipTrailingConstrains.isActive = nextUIProps.airplayButtonHidden
+                subtitlesEdgeTrailingConstrains.isActive = nextUIProps.airplayButtonHidden && nextUIProps.pipButtonHidden && !nextUIProps.settingsButtonHidden
+                subtitlesPipTrailingConstrains.isActive = nextUIProps.airplayButtonHidden && !nextUIProps.pipButtonHidden
             }
             switch (currentUIProps.bottomItemsHidden, nextUIProps.bottomItemsHidden) {
             case (false, true):
@@ -413,10 +413,9 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             case (true, false):
                 addAnimation(view: sideBarView, keyPath: "position") {}
                 sideBarView.isHidden = false
-                sideBarVisibleConstraint.isActive = true
                 sideBarInvisibleConstraint.isActive = false
-                
                 sideBarBottomConstraint.isActive = false
+                sideBarVisibleConstraint.isActive = true
             default:
                 guard sideBarView.layer.animationKeys() == nil || state.isTransitioning else { return }
                 sideBarView.isHidden = nextUIProps.sideBarViewHidden
@@ -694,7 +693,7 @@ public final class DefaultControlsViewController: ContentControlsViewController 
             
             visibleControlsSubtitlesConstraint.constant = {
                 let constant = traitCollection.userInterfaceIdiom == .pad ? 130 : 110
-                var distance = nextUIProps.bottomItemsHidden && !nextUIProps.seekerViewHidden ? 60 : 30
+                let distance = nextUIProps.bottomItemsHidden && !nextUIProps.seekerViewHidden ? 60 : 30
                 
                 return .init(nextUIProps.controlsViewHidden || nextUIProps.bottomItemsHidden ? distance : constant)
             }()


### PR DESCRIPTION
### Fixed constraint warnings for:
- `Sidebar view`
- `Seeker view`
- `Airplay view` and `Pip button`

### Changes:
- Removed size classes dependencies for all views;
- Added necessary checks in `setupBottomItemsConstraints` to prevent turning on constraint when it is not possible;
- Fixed constraint switch for the sidebar in `renderSideBar` method;
- Minor fixes in code.

@aol-public/mobile-sdk-team: Ready for review.

[JIRA Issue](https://jira.ouroath.com/browse/OMSDK-851)