### PR TITLE
Removed unnecessary logic for sidebar's constraint

### DIFF
--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -423,10 +423,6 @@ public final class DefaultControlsViewController: ContentControlsViewController 
                 sideBarVisibleConstraint.isActive = !nextUIProps.sideBarViewHidden
                 sideBarInvisibleConstraint.isActive = nextUIProps.sideBarViewHidden
                 sideBarBottomConstraint.isActive = nextUIProps.sideBarViewHidden
-                sideBarBottomConstraint.constant = {
-                    guard #available(iOS 11, *) else { return view.frame.height - sideBarView.frame.height }
-                    return view.frame.height - sideBarView.frame.height - view.safeAreaInsets.top
-                }()
             }
         }
         


### PR DESCRIPTION
I've added that logic to ensure that sidebar will appear exactly when expected even after transition. 
After some changes in xib, this logic is not needed anymore. In fact, it now causes a bug on an iPad, so I've removed it at all.

@aol-public/mobile-sdk-team: Ready for review.

[JIRA Issue](https://jira.ouroath.com/browse/OMSDK-869)
