### PR TITLE
Added double tap recognizer to toggle content video gravity

### DIFF
--- a/Demo/Demo/AppDelegate.swift
+++ b/Demo/Demo/AppDelegate.swift
@@ -7,6 +7,19 @@ import PlayerControls
 typealias Props = ContentControlsViewController.Props
 
 func props(progress: ContentControlsViewController.Props.Progress = 0) -> Props {
+    func backgroundColor() {
+        guard let view = UIApplication.shared.windows.first?.rootViewController?.view else { return }
+        switch view.backgroundColor {
+        case UIColor.red?:
+            view.backgroundColor = .blue
+            view.tintColor = .red
+        case UIColor.blue?:
+            view.backgroundColor = .red
+            view.tintColor = .blue
+        default:
+            break
+        }
+    }
     return Props.player(Props.Player(
         playlist: Props.Playlist(
             next: .nop,
@@ -49,7 +62,7 @@ func props(progress: ContentControlsViewController.Props.Progress = 0) -> Props 
             thumbnail: nil,
             title: "Title",
             animationsEnabled: true,
-            fullScreenContent: .nop))))
+            contentFullScreen: .init(action: backgroundColor)))))
 }
 
 @UIApplicationMain
@@ -136,4 +149,3 @@ func sideProps() -> [SideBarView.ButtonProps]{
     
     return [later, favorite, share, add]
 }
-

--- a/Demo/Demo/AppDelegate.swift
+++ b/Demo/Demo/AppDelegate.swift
@@ -48,7 +48,8 @@ func props(progress: ContentControlsViewController.Props.Progress = 0) -> Props 
             sideBarViewHidden: false,
             thumbnail: nil,
             title: "Title",
-            animationsEnabled: true))))
+            animationsEnabled: true,
+            fullScreenContent: .nop))))
 }
 
 @UIApplicationMain

--- a/PlayerControls/resources/DefaultControlsViewController.xib
+++ b/PlayerControls/resources/DefaultControlsViewController.xib
@@ -28,6 +28,7 @@
                 <outlet property="compasDirectionView" destination="6eW-2a-aeL" id="Anp-D7-5hp"/>
                 <outlet property="compassBodyBelowLiveTopConstraint" destination="qaS-Tx-ZER" id="zYF-dC-uGB"/>
                 <outlet property="compassBodyNoLiveTopConstraint" destination="mIu-gb-Ffc" id="uoM-nz-rEp"/>
+                <outlet property="contentFullScreenGestureRecognizer" destination="tba-DC-Y3K" id="jdL-pL-AqW"/>
                 <outlet property="controlsView" destination="fi9-sW-1VX" id="dg0-wz-bBh"/>
                 <outlet property="durationTextLabel" destination="Im0-Vw-2gZ" id="7UT-l7-dfO"/>
                 <outlet property="errorLabel" destination="UtD-cb-Wlb" id="ebo-gb-gDd"/>
@@ -36,6 +37,7 @@
                 <outlet property="liveViewTopConstraint" destination="8xl-GB-75a" id="u7k-aX-8EW"/>
                 <outlet property="loadingImageView" destination="ikX-6f-FSq" id="VZj-CY-bUg"/>
                 <outlet property="nextButton" destination="ida-wI-kAP" id="VKy-6n-hIb"/>
+                <outlet property="onEmptySpaceGestureRecognizer" destination="ydI-nT-cAb" id="cXk-b0-rkL"/>
                 <outlet property="pauseButton" destination="KeK-cX-xXB" id="ItP-y0-YdS"/>
                 <outlet property="pipButton" destination="tGV-rG-prj" id="lzF-NF-w8X"/>
                 <outlet property="playButton" destination="U8A-X2-cyf" id="PIP-Q8-Upy"/>
@@ -65,7 +67,7 @@
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tapGestureRecognizer id="ydI-nT-cAb">
             <connections>
-                <action selector="onEmptySpaceTap" destination="-1" id="1yi-FP-bhE"/>
+                <action selector="onEmptySpaceTap:" destination="-1" id="KGg-b9-Ppg"/>
             </connections>
         </tapGestureRecognizer>
         <view clipsSubviews="YES" contentMode="scaleToFill" id="rFH-6N-3gH">
@@ -446,6 +448,7 @@ Title</string>
             <connections>
                 <outletCollection property="gestureRecognizers" destination="ydI-nT-cAb" appends="YES" id="w9x-Nr-aVL"/>
                 <outletCollection property="gestureRecognizers" destination="ZiF-3w-BsH" appends="YES" id="gz4-El-Rax"/>
+                <outletCollection property="gestureRecognizers" destination="tba-DC-Y3K" appends="YES" id="yAJ-n6-6rI"/>
             </connections>
             <point key="canvasLocation" x="32.5" y="51.5"/>
         </view>
@@ -454,6 +457,11 @@ Title</string>
                 <action selector="onCameraPanWith:" destination="-1" id="RBn-Hb-4of"/>
             </connections>
         </panGestureRecognizer>
+        <tapGestureRecognizer numberOfTapsRequired="2" id="tba-DC-Y3K">
+            <connections>
+                <action selector="onEmptySpaceDoubleTap:" destination="-1" id="wYu-uK-JoJ"/>
+            </connections>
+        </tapGestureRecognizer>
     </objects>
     <resources>
         <image name="compas-body" width="30" height="30"/>

--- a/PlayerControls/sources/ContentControlsUIProps+Init.swift
+++ b/PlayerControls/sources/ContentControlsUIProps+Init.swift
@@ -33,7 +33,9 @@ extension ContentControlsViewController.Props.Controls {
                 sideBarViewHidden: Bool,
                 thumbnail: ContentControlsViewController.Props.Thumbnail?,
                 title: String,
-                animationsEnabled: Bool) {
+                animationsEnabled: Bool,
+                fullScreenContent: Command) {
+        self.contentFullScreen = fullScreenContent
         self.animationsEnabled = animationsEnabled
         self.title = title
         self.thumbnail = thumbnail

--- a/PlayerControls/sources/ContentControlsUIProps+Init.swift
+++ b/PlayerControls/sources/ContentControlsUIProps+Init.swift
@@ -34,8 +34,8 @@ extension ContentControlsViewController.Props.Controls {
                 thumbnail: ContentControlsViewController.Props.Thumbnail?,
                 title: String,
                 animationsEnabled: Bool,
-                fullScreenContent: Command) {
-        self.contentFullScreen = fullScreenContent
+                contentFullScreen: Command) {
+        self.contentFullScreen = contentFullScreen
         self.animationsEnabled = animationsEnabled
         self.title = title
         self.thumbnail = thumbnail

--- a/PlayerControls/sources/ContentControlsUIProps.swift
+++ b/PlayerControls/sources/ContentControlsUIProps.swift
@@ -84,6 +84,7 @@ extension DefaultControlsViewController {
         var liveDotColor: UIColor?
         
         var animationsEnabled: Bool
+        var contentFullScreenAction: Command
         
         //swiftlint:disable function_body_length
         //swiftlint:disable cyclomatic_complexity
@@ -272,6 +273,8 @@ extension DefaultControlsViewController {
                     else { return false }
                 return true
             }()
+            
+            contentFullScreenAction = props.player?.item.playable?.contentFullScreen ?? .nop
         }
     }
 }

--- a/PlayerControls/sources/ContentControlsViewController.swift
+++ b/PlayerControls/sources/ContentControlsViewController.swift
@@ -65,6 +65,7 @@ extension ContentControlsViewController.Props {
         public var audible: MediaGroupControl?
         public var settings: Settings = .disabled
         public var airplay: AirPlay = .enabled
+        public var contentFullScreen: Command = .nop
 
         public init() {}
     }

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -46,7 +46,11 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     @IBOutlet private var sideBarView: SideBarView!
     @IBOutlet private var errorLabel: UILabel!
     @IBOutlet private var retryButton: UIButton!
+    
+    @IBOutlet private var onEmptySpaceGestureRecognizer: UITapGestureRecognizer!
+    @IBOutlet private var contentFullScreenGestureRecognizer: UITapGestureRecognizer!
     @IBOutlet private var cameraPanGestureRecognizer: UIPanGestureRecognizer!
+    
     @IBOutlet private var pipButton: UIButton!
     @IBOutlet private var settingsButton: UIButton!
     @IBOutlet private var airPlayView: AirPlayView!
@@ -102,6 +106,10 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         seekerView.callbacks.onDragFinished = CommandWith { [unowned self] value in
             self.stopSeek(at: value)
         }
+        
+        onEmptySpaceGestureRecognizer.require(toFail: contentFullScreenGestureRecognizer)
+        
+        contentFullScreenGestureRecognizer.delegate = self
     }
     
     private var state = State()
@@ -904,8 +912,12 @@ public final class DefaultControlsViewController: ContentControlsViewController 
         onUserInteraction?.perform()
     }
     
-    @IBAction private func onEmptySpaceTap() {
+    @IBAction private func onEmptySpaceTap(_ sender: UITapGestureRecognizer) {
         onTapEvent?.perform()
+    }
+    
+    @IBAction private func onEmptySpaceDoubleTap(_ sender: UITapGestureRecognizer) {
+        currentUIProps.contentFullScreenAction.perform()
     }
     
     @IBAction private func onCameraPan(with recognizer: UIPanGestureRecognizer) {
@@ -932,5 +944,14 @@ public final class DefaultControlsViewController: ContentControlsViewController 
     
     @IBAction private func settingsButtonTouched() {
         currentUIProps.settingsButtonAction.perform()
+    }
+}
+
+extension DefaultControlsViewController: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        if touch.view is UIButton {
+            return false
+        }
+        return true
     }
 }

--- a/PlayerControls/sources/DefaultControlsViewController.swift
+++ b/PlayerControls/sources/DefaultControlsViewController.swift
@@ -949,9 +949,6 @@ public final class DefaultControlsViewController: ContentControlsViewController 
 
 extension DefaultControlsViewController: UIGestureRecognizerDelegate {
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        if touch.view is UIButton {
-            return false
-        }
-        return true
+        return !(touch.view is UIButton)
     }
 }


### PR DESCRIPTION
## Content Full Screen feature

### Changes
- Implemented double tap gesture recognizer;
- Added gesture recognizer delegate that won't send double taps through buttons;
- Added contentFullScreen property;
- One tap gesture recognizer now works only if double tap fails;
- Updated demo with background color switch to demonstrate how two gesture recognizers work;

### For discussion
- Naming - looking forward for your propositions about naming;
- Controls hide/show on tap delay, because tap gesture now will be triggered after double tap fails.
```swift
onEmptySpaceGestureRecognizer.require(toFail: contentFullScreenGestureRecognizer)
```
There's now a small delay before `onEmptySpaceGestureRecognizer` will be triggered. It is typical behavior for default AVPlayerViewController, but we should increase `animationDuration` for better UX.

@aol-public/mobile-sdk-team: Ready for review.

[JIRA Issue](https://jira.ouroath.com/browse/OMSDK-896)