### PR TITLE
Minor fixes in podspec with source files

### DIFF
--- a/PlayerControls.podspec
+++ b/PlayerControls.podspec
@@ -20,9 +20,9 @@ Pod::Spec.new do |s|
 
   s.source = { :git => 'https://github.com/aol-public/OneMobileSDK-controls-ios.git',
                :tag => s.version.to_s }   
-  s.source_files     = 'PlayerControls/sources/**/*.swift'
+  s.source_files     = 'PlayerControls/**/*.swift'
+  s.exclude_files    = 'PlayerControls/tests/*'
   s.resource         = 'PlayerControls/resources/*'
-  s.exclude_files    = '*Test*'
 
   s.ios.deployment_target = '9.0'
   s.requires_arc = true


### PR DESCRIPTION
## Changes
- Sources now get all swift files from `PlayerControls` folder to be able to reach `Autogeneretable.swift` file
- Excluded `tests` folder

@aol-public/mobile-sdk-team: Ready for review.

[JIRA Issue](https://jira.ouroath.com/browse/OMSDK-1573)
